### PR TITLE
feat(report-definition): Add multi-definition support with definition…

### DIFF
--- a/FinancialReport/DAC/FLRTFinancialReport.cs
+++ b/FinancialReport/DAC/FLRTFinancialReport.cs
@@ -148,12 +148,14 @@ namespace FinancialReport
 
     #region DefinitionID
     /// <summary>
-    /// Links this report record to a Report Definition (Balance Sheet, P&L, etc.).
-    /// When set, the ReportCalculationEngine is used instead of raw placeholder matching.
-    /// Leave blank to use the legacy account-code placeholder approach.
+    /// Legacy single-definition link. Superseded by FLRTReportDefinitionLink child table
+    /// which supports multiple definitions per report with cross-definition formulas.
+    ///
+    /// If FLRTReportDefinitionLink rows exist for this report, this field is ignored.
+    /// Kept for backward compatibility with reports created before multi-definition support.
     /// </summary>
     [PXDBInt]
-    [PXUIField(DisplayName = "Report Definition")]
+    [PXUIField(DisplayName = "Report Definition (Legacy)", Visible = false)]
     [PXSelector(
         typeof(Search<FLRTReportDefinition.definitionID>),
         typeof(FLRTReportDefinition.definitionCD),

--- a/FinancialReport/DAC/FLRTReportDefinition.cs
+++ b/FinancialReport/DAC/FLRTReportDefinition.cs
@@ -23,11 +23,26 @@ namespace FinancialReport
         [PXDefault]
         [PXSelector(typeof(FLRTReportDefinition.definitionCD),
             typeof(FLRTReportDefinition.definitionCD),
+            typeof(FLRTReportDefinition.definitionPrefix),
             typeof(FLRTReportDefinition.description),
             typeof(FLRTReportDefinition.reportType),
             Filterable = true)]
         public virtual string DefinitionCD { get; set; }
         public abstract class definitionCD : PX.Data.BQL.BqlString.Field<definitionCD> { }
+        #endregion
+
+        #region DefinitionPrefix
+        /// <summary>
+        /// Short alphanumeric prefix (2-10 chars) used to namespace placeholder keys
+        /// when this definition is used in a multi-definition report.
+        /// Example: "BS" produces {{BS_TOTAL_ASSETS_CY}} in the Word template.
+        /// Must be unique across all definitions and contain only letters/digits.
+        /// </summary>
+        [PXDBString(10, IsUnicode = true)]
+        [PXUIField(DisplayName = "Prefix")]
+        [PXDefault]
+        public virtual string DefinitionPrefix { get; set; }
+        public abstract class definitionPrefix : PX.Data.BQL.BqlString.Field<definitionPrefix> { }
         #endregion
 
         #region Description

--- a/FinancialReport/DAC/FLRTReportDefinitionLink.cs
+++ b/FinancialReport/DAC/FLRTReportDefinitionLink.cs
@@ -1,0 +1,107 @@
+using System;
+using PX.Data;
+using PX.Data.BQL.Fluent;
+
+namespace FinancialReport
+{
+    /// <summary>
+    /// Links one or more Report Definitions to a single Financial Report record.
+    /// Replaces the legacy single DefinitionID field on FLRTFinancialReport.
+    ///
+    /// Each linked definition contributes its calculated line values (prefixed by
+    /// FLRTReportDefinition.DefinitionPrefix) to the unified placeholder dictionary.
+    /// Cross-definition formula references are resolved via topological sort in
+    /// ReportCalculationEngine.CalculateAll().
+    /// </summary>
+    [Serializable]
+    [PXCacheName("FLRT Report Definition Link")]
+    public class FLRTReportDefinitionLink : PXBqlTable, IBqlTable
+    {
+        #region LinkID
+        [PXDBIdentity(IsKey = true)]
+        [PXUIField(DisplayName = "Link ID", Visible = false)]
+        public virtual int? LinkID { get; set; }
+        public abstract class linkID : PX.Data.BQL.BqlInt.Field<linkID> { }
+        #endregion
+
+        #region ReportID
+        [PXDBInt]
+        [PXDBDefault(typeof(FLRTFinancialReport.reportID))]
+        [PXParent(typeof(SelectFrom<FLRTFinancialReport>
+            .Where<FLRTFinancialReport.reportID.IsEqual<reportID.FromCurrent>>))]
+        [PXUIField(DisplayName = "Report ID", Visible = false)]
+        public virtual int? ReportID { get; set; }
+        public abstract class reportID : PX.Data.BQL.BqlInt.Field<reportID> { }
+        #endregion
+
+        #region DefinitionID
+        [PXDBInt]
+        [PXUIField(DisplayName = "Definition")]
+        [PXDefault]
+        [PXSelector(
+            typeof(Search<FLRTReportDefinition.definitionID>),
+            typeof(FLRTReportDefinition.definitionCD),
+            typeof(FLRTReportDefinition.definitionPrefix),
+            typeof(FLRTReportDefinition.description),
+            typeof(FLRTReportDefinition.reportType),
+            SubstituteKey = typeof(FLRTReportDefinition.definitionCD),
+            DescriptionField = typeof(FLRTReportDefinition.description))]
+        public virtual int? DefinitionID { get; set; }
+        public abstract class definitionID : PX.Data.BQL.BqlInt.Field<definitionID> { }
+        #endregion
+
+        #region DefinitionPrefix
+        /// <summary>
+        /// Read-only display of the selected definition's prefix.
+        /// Populated via FieldSelecting event — not stored in DB.
+        /// </summary>
+        [PXString(10, IsUnicode = true)]
+        [PXUIField(DisplayName = "Prefix", Enabled = false)]
+        public virtual string DefinitionPrefix { get; set; }
+        public abstract class definitionPrefix : PX.Data.BQL.BqlString.Field<definitionPrefix> { }
+        #endregion
+
+        #region DisplayOrder
+        /// <summary>
+        /// Controls the display order of this row in the grid only.
+        /// Has NO effect on calculation order — calculation order is determined
+        /// entirely by topological sort of cross-definition dependencies.
+        /// </summary>
+        [PXDBInt]
+        [PXDefault(0)]
+        [PXUIField(DisplayName = "Display Order")]
+        public virtual int? DisplayOrder { get; set; }
+        public abstract class displayOrder : PX.Data.BQL.BqlInt.Field<displayOrder> { }
+        #endregion
+
+        #region Audit Fields
+        [PXDBCreatedDateTime]
+        public virtual DateTime? CreatedDateTime { get; set; }
+        public abstract class createdDateTime : PX.Data.BQL.BqlDateTime.Field<createdDateTime> { }
+
+        [PXDBCreatedByID]
+        public virtual Guid? CreatedByID { get; set; }
+        public abstract class createdByID : PX.Data.BQL.BqlGuid.Field<createdByID> { }
+
+        [PXDBCreatedByScreenID]
+        public virtual string CreatedByScreenID { get; set; }
+        public abstract class createdByScreenID : PX.Data.BQL.BqlString.Field<createdByScreenID> { }
+
+        [PXDBLastModifiedDateTime]
+        public virtual DateTime? LastModifiedDateTime { get; set; }
+        public abstract class lastModifiedDateTime : PX.Data.BQL.BqlDateTime.Field<lastModifiedDateTime> { }
+
+        [PXDBLastModifiedByID]
+        public virtual Guid? LastModifiedByID { get; set; }
+        public abstract class lastModifiedByID : PX.Data.BQL.BqlGuid.Field<lastModifiedByID> { }
+
+        [PXDBLastModifiedByScreenID]
+        public virtual string LastModifiedByScreenID { get; set; }
+        public abstract class lastModifiedByScreenID : PX.Data.BQL.BqlString.Field<lastModifiedByScreenID> { }
+
+        [PXDBTimestamp]
+        public virtual byte[] Tstamp { get; set; }
+        public abstract class tstamp : PX.Data.BQL.BqlByteArray.Field<tstamp> { }
+        #endregion
+    }
+}

--- a/FinancialReport/DAC/FLRTReportLineItem.cs
+++ b/FinancialReport/DAC/FLRTReportLineItem.cs
@@ -139,8 +139,8 @@ namespace FinancialReport
         [PXDefault(BalanceTypeValue.Ending)]
         [PXUIField(DisplayName = "Balance Type")]
         [PXStringList(
-            new string[] { BalanceTypeValue.Ending, BalanceTypeValue.Beginning, BalanceTypeValue.Debit, BalanceTypeValue.Credit, BalanceTypeValue.Movement },
-            new string[] { "Ending Balance", "Beginning Balance", "Debit", "Credit", "Movement" }
+            new string[] { BalanceTypeValue.Ending, BalanceTypeValue.Beginning, BalanceTypeValue.JanuaryBeginning, BalanceTypeValue.Debit, BalanceTypeValue.Credit, BalanceTypeValue.Movement },
+            new string[] { "Ending Balance", "Beginning Balance", "January Beginning Balance", "Debit", "Credit", "Movement" }
         )]
         public virtual string BalanceType { get; set; }
         public abstract class balanceType : PX.Data.BQL.BqlString.Field<balanceType> { }
@@ -301,11 +301,16 @@ namespace FinancialReport
 
         public static class BalanceTypeValue
         {
-            public const string Ending    = "ENDING";
-            public const string Beginning = "BEGINNING";
-            public const string Debit     = "DEBIT";
-            public const string Credit    = "CREDIT";
-            public const string Movement  = "MOVEMENT";
+            public const string Ending            = "ENDING";
+            public const string Beginning         = "BEGINNING";
+            /// <summary>
+            /// Explicitly uses the BeginningBalance of period 01-{Year} (January).
+            /// Equivalent to Beginning for December fiscal-year-end; differs for other month-ends.
+            /// </summary>
+            public const string JanuaryBeginning  = "JANBEGINNING";
+            public const string Debit             = "DEBIT";
+            public const string Credit            = "CREDIT";
+            public const string Movement          = "MOVEMENT";
         }
 
         public static class AccountTypeValue

--- a/FinancialReport/FinancialReport.csproj
+++ b/FinancialReport/FinancialReport.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Services\ReportGenerationService.cs" />
     <Compile Include="Services\WordTemplateService.cs" />
     <Compile Include="DAC\FLRTReportDefinition.cs" />
+    <Compile Include="DAC\FLRTReportDefinitionLink.cs" />
     <Compile Include="DAC\FLRTReportLineItem.cs" />
     <Compile Include="Graph\FLRTReportDefinitionMaint.cs" />
     <Compile Include="Services\ReportCalculationEngine.cs" />

--- a/FinancialReport/Graph/FLRTFinancialReportMaint.cs
+++ b/FinancialReport/Graph/FLRTFinancialReportMaint.cs
@@ -11,39 +11,88 @@ using static FinancialReport.FLRTFinancialReport;
 
 namespace FinancialReport
 {
-    public class FLRTFinancialReportMaint : PXGraph<FLRTFinancialReportMaint>
+    public class FLRTFinancialReportMaint : PXGraph<FLRTFinancialReportMaint, FLRTFinancialReport>
     {
         #region DAC View
         public SelectFrom<FLRTFinancialReport>.View FinancialReport = null!; // Initialized by PXGraph framework
+
+        /// <summary>
+        /// Child grid: linked Report Definitions for the currently selected report.
+        /// Each row ties one definition (with its prefix) to this report.
+        /// Multiple definitions enable cross-definition formulas and a single unified output.
+        /// </summary>
+        public SelectFrom<FLRTReportDefinitionLink>
+            .Where<FLRTReportDefinitionLink.reportID.IsEqual<FLRTFinancialReport.reportID.FromCurrent>>
+            .OrderBy<FLRTReportDefinitionLink.displayOrder.Asc>
+            .View DefinitionLinks;
         #endregion
 
         #region Events
-        protected void FLRTFinancialReport_Selected_FieldUpdated(PXCache cache, PXFieldUpdatedEventArgs e)
-        {
-            var current = (FLRTFinancialReport)e.Row;
-            if (current?.Selected != true) return;
 
-            foreach (FLRTFinancialReport item in FinancialReport.Cache.Cached)
+        // ── FLRTReportDefinitionLink events ──────────────────────────────────
+
+        /// <summary>
+        /// Populates the read-only Prefix display column from the joined FLRTReportDefinition.
+        /// </summary>
+        protected void _(Events.FieldSelecting<FLRTReportDefinitionLink, FLRTReportDefinitionLink.definitionPrefix> e)
+        {
+            if (e.Row?.DefinitionID == null) return;
+            var def = PXSelectorAttribute.Select<FLRTReportDefinitionLink.definitionID>(e.Cache, e.Row) as FLRTReportDefinition;
+            if (def != null)
+                e.ReturnValue = def.DefinitionPrefix;
+        }
+
+        /// <summary>
+        /// Validates that linked definitions have unique prefixes within this report.
+        /// </summary>
+        protected void _(Events.RowPersisting<FLRTReportDefinitionLink> e)
+        {
+            if (e.Row == null || e.Operation == PXDBOperation.Delete) return;
+
+            // Ensure a definition is selected
+            if (e.Row.DefinitionID == null)
             {
-                if (item.ReportID != current.ReportID && item.Selected == true)
+                e.Cache.RaiseExceptionHandling<FLRTReportDefinitionLink.definitionID>(
+                    e.Row, e.Row.DefinitionID,
+                    new PXSetPropertyException(Messages.DefinitionRequired, PXErrorLevel.Error));
+                return;
+            }
+
+            // Load the definition to get its prefix
+            var def = PXSelectorAttribute.Select<FLRTReportDefinitionLink.definitionID>(e.Cache, e.Row) as FLRTReportDefinition;
+            if (def == null || string.IsNullOrWhiteSpace(def.DefinitionPrefix)) return;
+
+            // Check for duplicate prefix among other links for the same report
+            foreach (FLRTReportDefinitionLink other in DefinitionLinks.Cache.Cached)
+            {
+                if (other.LinkID == e.Row.LinkID) continue;
+                if (other.DefinitionID == null) continue;
+
+                var otherDef = PXSelectorAttribute.Select<FLRTReportDefinitionLink.definitionID>(
+                    DefinitionLinks.Cache, other) as FLRTReportDefinition;
+
+                if (otherDef != null
+                    && string.Equals(otherDef.DefinitionPrefix, def.DefinitionPrefix, System.StringComparison.OrdinalIgnoreCase))
                 {
-                    item.Selected = false;
+                    e.Cache.RaiseExceptionHandling<FLRTReportDefinitionLink.definitionID>(
+                        e.Row, e.Row.DefinitionID,
+                        new PXSetPropertyException(Messages.DuplicatePrefixInReport, PXErrorLevel.Error, def.DefinitionPrefix));
+                    return;
                 }
             }
         }
+
+        // ── FLRTFinancialReport events ────────────────────────────────────────
 
         protected void FLRTFinancialReport_RowSelected(PXCache cache, PXRowSelectedEventArgs e)
         {
             var row = (FLRTFinancialReport)e.Row;
             if (row == null) return;
 
-            bool anyInProgress = FinancialReport.Cache.Cached
-                .Cast<FLRTFinancialReport>()
-                .Any(r => r.Status == ReportStatus.InProgress);
-
-            PXUIFieldAttribute.SetEnabled(cache, row, !anyInProgress);
-            GenerateReport.SetEnabled(!anyInProgress);
-            DownloadReport.SetEnabled(!anyInProgress);
+            bool isInProgress = row.Status == ReportStatus.InProgress;
+            PXUIFieldAttribute.SetEnabled(cache, row, !isInProgress);
+            GenerateReport.SetEnabled(!isInProgress);
+            DownloadReport.SetEnabled(!isInProgress);
         }
 
         protected void FLRTFinancialReport_RowPersisting(PXCache cache, PXRowPersistingEventArgs e)
@@ -76,16 +125,7 @@ namespace FinancialReport
             }
         }
 
-        protected virtual void FLRTFinancialReport_RowInserted(PXCache sender, PXRowInsertedEventArgs e)
-        {
-            // Acuminator disable once PX1043 SavingChangesInEventHandlers [Justification]
-            this.Actions.PressSave();
-            FinancialReport.Current = null!; // Clear current record in Acumatica framework
-            FinancialReport.Cache.Clear();
-            FinancialReport.Cache.ClearQueryCache();
-            FinancialReport.View.Clear();
-        }
-        #endregion
+#endregion
 
         #region Actions
         public PXSave<FLRTFinancialReport> Save = null!; // Initialized by PXGraph framework
@@ -98,9 +138,7 @@ namespace FinancialReport
         [PXUIField(DisplayName = "Generate Report")]
         protected virtual System.Collections.IEnumerable generateReport(PXAdapter adapter)
         {
-            var selectedRecord = FinancialReport.Cache.Cached
-                .Cast<FLRTFinancialReport>()
-                .FirstOrDefault(item => item.Selected == true);
+            var selectedRecord = FinancialReport.Current;
 
             // Perform initial validations on the UI thread
             if (selectedRecord == null) throw new PXException(Messages.PleaseSelectTemplate);
@@ -245,9 +283,7 @@ namespace FinancialReport
         [PXUIField(DisplayName = "Download Report", MapEnableRights = PXCacheRights.Select, Visible = true)]
         protected virtual System.Collections.IEnumerable downloadReport(PXAdapter adapter)
         {
-            var selectedRecord = FinancialReport.Cache.Cached
-                .Cast<FLRTFinancialReport>()
-                .FirstOrDefault(x => x.Selected == true);
+            var selectedRecord = FinancialReport.Current;
 
             if (selectedRecord == null)
                 throw new PXException(Messages.NoRecordIsSelected);
@@ -262,9 +298,7 @@ namespace FinancialReport
         [PXUIField(DisplayName = "Reset Status", MapEnableRights = PXCacheRights.Update, Visible = true)]
         protected virtual System.Collections.IEnumerable resetStatus(PXAdapter adapter)
         {
-            var selectedRecord = FinancialReport.Cache.Cached
-                .Cast<FLRTFinancialReport>()
-                .FirstOrDefault(x => x.Selected == true);
+            var selectedRecord = FinancialReport.Current;
 
             if (selectedRecord == null)
             {

--- a/FinancialReport/Graph/FLRTReportDefinitionMaint.cs
+++ b/FinancialReport/Graph/FLRTReportDefinitionMaint.cs
@@ -36,6 +36,8 @@ namespace FinancialReport
             if (e.Row == null) return;
             bool isNewRecord = e.Cache.GetStatus(e.Row) == PXEntryStatus.Inserted;
             PXUIFieldAttribute.SetEnabled<FLRTReportDefinition.definitionCD>(e.Cache, e.Row, isNewRecord);
+            // Prefix is also locked once saved to prevent breaking existing Word templates
+            PXUIFieldAttribute.SetEnabled<FLRTReportDefinition.definitionPrefix>(e.Cache, e.Row, isNewRecord);
             Actions["detectColumns"]?.SetEnabled(!string.IsNullOrWhiteSpace(e.Row.GIName));
         }
 
@@ -50,7 +52,38 @@ namespace FinancialReport
                     new PXSetPropertyException(Messages.DefinitionCodeRequired, PXErrorLevel.Error));
             }
 
-            // Uniqueness check
+            // Validate prefix is provided
+            if (string.IsNullOrWhiteSpace(e.Row.DefinitionPrefix))
+            {
+                e.Cache.RaiseExceptionHandling<FLRTReportDefinition.definitionPrefix>(
+                    e.Row, e.Row.DefinitionPrefix,
+                    new PXSetPropertyException(Messages.DefinitionPrefixRequired, PXErrorLevel.Error));
+                return;
+            }
+
+            // Validate prefix is alphanumeric only (no underscores, spaces, or special chars)
+            if (!System.Text.RegularExpressions.Regex.IsMatch(e.Row.DefinitionPrefix, @"^[A-Za-z0-9]+$"))
+            {
+                e.Cache.RaiseExceptionHandling<FLRTReportDefinition.definitionPrefix>(
+                    e.Row, e.Row.DefinitionPrefix,
+                    new PXSetPropertyException(Messages.DefinitionPrefixMustBeAlphanumeric, PXErrorLevel.Error));
+                return;
+            }
+
+            // Validate prefix uniqueness across all definitions
+            FLRTReportDefinition duplicatePrefix = SelectFrom<FLRTReportDefinition>
+                .Where<FLRTReportDefinition.definitionPrefix.IsEqual<@P.AsString>
+                    .And<FLRTReportDefinition.definitionID.IsNotEqual<@P.AsInt>>>
+                .View.Select(this, e.Row.DefinitionPrefix, e.Row.DefinitionID ?? -1);
+
+            if (duplicatePrefix != null)
+            {
+                e.Cache.RaiseExceptionHandling<FLRTReportDefinition.definitionPrefix>(
+                    e.Row, e.Row.DefinitionPrefix,
+                    new PXSetPropertyException(Messages.DefinitionPrefixMustBeUnique, PXErrorLevel.Error));
+            }
+
+            // Validate DefinitionCD uniqueness
             FLRTReportDefinition duplicate = SelectFrom<FLRTReportDefinition>
                 .Where<FLRTReportDefinition.definitionCD.IsEqual<@P.AsString>
                     .And<FLRTReportDefinition.definitionID.IsNotEqual<@P.AsInt>>>
@@ -201,9 +234,17 @@ namespace FinancialReport
             if (ReportDefinition.Ask(Messages.ConfirmCopyDefinition, MessageButtons.YesNo) != WebDialogResult.Yes)
                 return adapter.Get();
 
+            // Build a unique copy prefix (truncate source prefix to 7 chars + "CP" suffix to stay within 10 chars)
+            string copyPrefix = string.IsNullOrWhiteSpace(source.DefinitionPrefix)
+                ? "COPY"
+                : (source.DefinitionPrefix.Length > 7
+                    ? source.DefinitionPrefix.Substring(0, 7) + "CP"
+                    : source.DefinitionPrefix + "CP");
+
             var newDef = new FLRTReportDefinition
             {
                 DefinitionCD       = source.DefinitionCD + "_COPY",
+                DefinitionPrefix   = copyPrefix,
                 Description        = source.Description + " (Copy)",
                 ReportType         = source.ReportType,
                 IsActive           = true,

--- a/FinancialReport/Graph/FLRTTenantCredentialsMaint.cs
+++ b/FinancialReport/Graph/FLRTTenantCredentialsMaint.cs
@@ -1,6 +1,5 @@
 using System;
 using PX.Data;
-using System.Text;
 using PX.Data.BQL.Fluent;
 
 namespace FinancialReport
@@ -18,43 +17,6 @@ namespace FinancialReport
         }
 
         #region Event Handlers
-        // FieldUpdating to convert string input from UI to byte[]
-        protected void FLRTTenantCredentials_ClientID_FieldUpdating(PXCache cache, PXFieldUpdatingEventArgs e)
-        {
-            if (e.NewValue is string stringValue && !string.IsNullOrEmpty(stringValue))
-            {
-                PXTrace.WriteInformation($"Converting ClientID: {stringValue}");
-                e.NewValue = Encoding.UTF8.GetBytes(stringValue);
-            }
-        }
-
-        protected void FLRTTenantCredentials_SecretID_FieldUpdating(PXCache cache, PXFieldUpdatingEventArgs e)
-        {
-            if (e.NewValue is string stringValue && !string.IsNullOrEmpty(stringValue))
-            {
-                PXTrace.WriteInformation($"Converting SecretID: {stringValue}");
-                e.NewValue = Encoding.UTF8.GetBytes(stringValue);
-            }
-        }
-
-        protected void FLRTTenantCredentials_Username_FieldUpdating(PXCache cache, PXFieldUpdatingEventArgs e)
-        {
-            if (e.NewValue is string stringValue && !string.IsNullOrEmpty(stringValue))
-            {
-                PXTrace.WriteInformation($"Converting Username: {stringValue}");
-                e.NewValue = Encoding.UTF8.GetBytes(stringValue);
-            }
-        }
-
-        protected void FLRTTenantCredentials_Password_FieldUpdating(PXCache cache, PXFieldUpdatingEventArgs e)
-        {
-            if (e.NewValue is string stringValue && !string.IsNullOrEmpty(stringValue))
-            {
-                PXTrace.WriteInformation($"Converting Password: {stringValue}");
-                e.NewValue = Encoding.UTF8.GetBytes(stringValue);
-            }
-        }
-
         // RowPersisting for validation and logging
         protected void FLRTTenantCredentials_RowPersisting(PXCache cache, PXRowPersistingEventArgs e)
         {
@@ -105,11 +67,6 @@ namespace FinancialReport
                 }
             }
         }
-        #endregion
-
-        #region Helper Methods
-        public static byte[] StringToByteArray(string value) => Encoding.UTF8.GetBytes(value);
-        public static string ByteArrayToString(byte[] value) => value != null ? Encoding.UTF8.GetString(value) : string.Empty;
         #endregion
 
         #region Actions

--- a/FinancialReport/Helper/Messages.cs
+++ b/FinancialReport/Helper/Messages.cs
@@ -86,6 +86,9 @@ namespace FinancialReport
         // ==================================================
         public const string DefinitionCodeRequired = "Definition Code is required.";
         public const string DefinitionCodeMustBeUnique = "Definition Code must be unique.";
+        public const string DefinitionPrefixRequired = "Definition Prefix is required. Enter a short alphanumeric code (e.g. BS, PL, CF).";
+        public const string DefinitionPrefixMustBeAlphanumeric = "Definition Prefix must contain letters and digits only — no spaces, underscores, or special characters.";
+        public const string DefinitionPrefixMustBeUnique = "Definition Prefix must be unique across all definitions. Another definition already uses this prefix.";
         public const string LineCodeRequired = "Line Code is required.";
         public const string LineCodeMustBeUnique = "Line Code must be unique within the same definition.";
         public const string AccountFromRequired = "Account From is required for Account Range line types.";
@@ -95,6 +98,13 @@ namespace FinancialReport
         public const string NoDefinitionLineItems = "Report Definition has no line items configured. Please set up line items in the Report Definition screen.";
         public const string FormulaEvaluationFailed = "Formula evaluation failed for line '{0}': {1}";
         public const string UnknownFormulaLineCode = "Formula references unknown Line Code '{0}'. Ensure it is defined with a lower Sort Order.";
+
+        // ==================================================
+        // MULTI-DEFINITION REPORT MESSAGES
+        // ==================================================
+        public const string DefinitionRequired = "Please select a Report Definition.";
+        public const string DuplicatePrefixInReport = "Prefix '{0}' is already used by another linked definition in this report. Each definition must have a unique prefix.";
+        public const string CircularDependencyDetected = "Circular dependency detected in report definitions. The following line codes form a cycle and cannot be resolved: {0}. Please revise the formulas to break the cycle.";
 
         // ==================================================
         // GI & COLUMN MAPPING MESSAGES

--- a/FinancialReport/Services/ReportCalculationEngine.cs
+++ b/FinancialReport/Services/ReportCalculationEngine.cs
@@ -12,15 +12,19 @@ namespace FinancialReport.Services
     /// <summary>
     /// The core financial report calculation engine.
     ///
-    /// Given a Report Definition (set of line items with account ranges, sign rules,
-    /// subtotal groupings, and formulas) and pre-fetched GL data, this engine:
+    /// Supports both single-definition (legacy) and multi-definition (new) modes.
     ///
-    ///   1. Iterates line items in SortOrder sequence
-    ///   2. For ACCOUNT lines  → sums GL accounts in the range, applies sign rule
-    ///   3. For SUBTOTAL lines → sums all child lines (those pointing to this LineCode as parent)
-    ///   4. For CALCULATED lines → evaluates a formula expression referencing other LineCodes
-    ///   5. Produces a flat Dictionary of {{LINECODE_CY}} / {{LINECODE_PY}} placeholder values
-    ///      ready to be inserted directly into the Word template.
+    /// Multi-definition mode (CalculateAll):
+    ///   - Accepts any number of Report Definitions, each with a short prefix (e.g. "BS", "PL", "CF")
+    ///   - Loads all line items from all definitions into a single processing graph
+    ///   - Resolves cross-definition formula references (e.g. CF formula: BS_RETAINED_ASSETS - DISPOSED_ASSETS)
+    ///   - Uses topological sort (Kahn's algorithm) to determine the correct calculation order automatically
+    ///   - Detects circular dependencies and surfaces a clear error
+    ///   - Produces prefixed placeholder keys: PREFIX_LINECODE_CY / PREFIX_LINECODE_PY
+    ///
+    /// Formula token resolution:
+    ///   - Explicit:  "BS_TOTAL_ASSETS" → token starts with known prefix "BS_" → cross-definition reference
+    ///   - Implicit:  "TOTAL_ASSETS"    → no prefix match → own-definition, resolved as "CURRENTPREFIX_TOTAL_ASSETS"
     ///
     /// The engine is stateless — create a new instance per report generation.
     /// </summary>
@@ -29,10 +33,9 @@ namespace FinancialReport.Services
         private readonly PXGraph _graph;
         private readonly RoundingSettings _rounding;
 
-        // Holds calculated values as the engine processes lines in order.
-        // Key = LineCode (uppercase), Value = calculated decimal
-        private readonly Dictionary<string, decimal> _cyValues  = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, decimal> _pyValues  = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+        // Global dictionaries used during CalculateAll — keyed by PREFIX_LINECODE (uppercase)
+        private readonly Dictionary<string, decimal> _cyGlobal = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, decimal> _pyGlobal = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
 
         public ReportCalculationEngine(PXGraph graph, RoundingSettings rounding = null)
         {
@@ -40,126 +43,498 @@ namespace FinancialReport.Services
             _rounding = rounding ?? new RoundingSettings();
         }
 
+        // ─────────────────────────────────────────────────────────────────
+        // PUBLIC STRUCTS & CLASSES
+        // ─────────────────────────────────────────────────────────────────
+
         /// <summary>
-        /// Main entry point. Calculates all line values for a report definition
-        /// and returns a placeholder dictionary ready for Word template population.
+        /// Describes one Report Definition to be included in a multi-definition calculation.
         /// </summary>
-        /// <param name="definitionID">The Report Definition to use.</param>
-        /// <param name="cyData">GL data for the current year period.</param>
-        /// <param name="pyData">GL data for the prior year period.</param>
+        public struct DefinitionLink
+        {
+            /// <summary>The DB identity of the FLRTReportDefinition record.</summary>
+            public int DefinitionID { get; set; }
+
+            /// <summary>
+            /// Short alphanumeric prefix (e.g. "BS", "PL", "CF").
+            /// Namespaces all placeholder keys produced by this definition.
+            /// Prefix + "_" + LineCode + "_CY" = the Word template placeholder key.
+            /// </summary>
+            public string Prefix { get; set; }
+
+            /// <summary>Per-definition rounding configuration for value formatting.</summary>
+            public RoundingSettings Rounding { get; set; }
+        }
+
+        // ─────────────────────────────────────────────────────────────────
+        // INTERNAL NODE
+        // ─────────────────────────────────────────────────────────────────
+
+        private class LineNode
+        {
+            public FLRTReportLineItem Line     { get; set; }
+            public string            Prefix   { get; set; }
+            public int               DefinitionID { get; set; }
+            public RoundingSettings  Rounding { get; set; }
+
+            /// <summary>Global dictionary key: PREFIX_LINECODE (uppercase).</summary>
+            public string GlobalKey => $"{Prefix}_{Line.LineCode}".ToUpper();
+        }
+
+        // ─────────────────────────────────────────────────────────────────
+        // MULTI-DEFINITION ENTRY POINT
+        // ─────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Calculates all line values across multiple linked definitions in one pass.
+        /// Uses topological sort to determine calculation order automatically —
+        /// cross-definition references are resolved without any manual sequencing.
+        /// </summary>
+        /// <param name="definitionLinks">All definitions linked to this report.</param>
+        /// <param name="cyData">GL data for the current year period (shared across all definitions).</param>
+        /// <param name="pyData">GL data for the prior year period (shared across all definitions).</param>
+        /// <param name="cyOpeningData">
+        /// GL data for the end of the year BEFORE the current year — i.e. the fiscal-year opening balance
+        /// for CY lines with BalanceType=Beginning.  Pass prevYearData here.
+        /// When null, falls back to cyData.BeginningBalance (legacy behaviour).
+        /// </param>
+        /// <param name="pyOpeningData">
+        /// GL data for the end of the year BEFORE the prior year — i.e. the fiscal-year opening balance
+        /// for PY lines with BalanceType=Beginning.  Pass prevYearPriorData here.
+        /// When null, falls back to pyData.BeginningBalance (legacy behaviour).
+        /// </param>
+        /// <param name="cyJanOpeningData">
+        /// GL data fetched from period 01-{currYear} via FetchJanuaryBeginningBalance.
+        /// Used for BalanceType=JanuaryBeginning on CY lines (.BeginningBalance per account).
+        /// </param>
+        /// <param name="pyJanOpeningData">
+        /// GL data fetched from period 01-{prevYear} via FetchJanuaryBeginningBalance.
+        /// Used for BalanceType=JanuaryBeginning on PY lines (.BeginningBalance per account).
+        /// </param>
+        /// <param name="cyCumulativeData">
+        /// Year-to-date range data for CY (e.g. Jan–Dec of current year).
+        /// Used for BalanceType=Debit/Credit/Movement so the full-year totals are used,
+        /// not just the single year-end period's movement values.
+        /// </param>
+        /// <param name="pyCumulativeData">
+        /// Year-to-date range data for PY (e.g. Jan–Dec of prior year).
+        /// Used for BalanceType=Debit/Credit/Movement on PY lines.
+        /// </param>
         /// <returns>
-        /// Dictionary keyed by placeholder name (e.g. "CASH_CY", "NET_INCOME_PY").
-        /// Values are formatted strings (e.g. "50,000" or "(30,000)" for negatives).
+        /// Unified placeholder dictionary keyed as PREFIX_LINECODE_CY / PREFIX_LINECODE_PY.
+        /// E.g. "BS_TOTAL_ASSETS_CY", "PL_NET_INCOME_PY"
         /// </returns>
+        public Dictionary<string, string> CalculateAll(
+            IEnumerable<DefinitionLink> definitionLinks,
+            FinancialApiData cyData,
+            FinancialApiData pyData,
+            FinancialApiData cyOpeningData = null,
+            FinancialApiData pyOpeningData = null,
+            FinancialApiData cyJanOpeningData = null,
+            FinancialApiData pyJanOpeningData = null,
+            FinancialApiData cyCumulativeData = null,
+            FinancialApiData pyCumulativeData = null)
+        {
+            _cyGlobal.Clear();
+            _pyGlobal.Clear();
+
+            var linkList = definitionLinks?.ToList();
+            if (linkList == null || !linkList.Any())
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            // Collect known prefixes for formula token resolution
+            var knownPrefixes = new HashSet<string>(
+                linkList.Select(l => l.Prefix?.ToUpper()).Where(p => !string.IsNullOrEmpty(p)),
+                StringComparer.OrdinalIgnoreCase);
+
+            PXTrace.WriteInformation($"ReportCalculationEngine.CalculateAll: {linkList.Count} definition(s), prefixes: [{string.Join(", ", knownPrefixes)}]");
+
+            // 1. Load all line items from all definitions
+            var allNodes = LoadAllLineItems(linkList);
+            if (!allNodes.Any())
+            {
+                PXTrace.WriteWarning("ReportCalculationEngine.CalculateAll: No line items found across all definitions.");
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            PXTrace.WriteInformation($"ReportCalculationEngine.CalculateAll: {allNodes.Count} total line items loaded.");
+
+            // 2. Build dependency graph and topologically sort
+            var sortedNodes = BuildAndSort(allNodes, knownPrefixes);
+
+            // 3. Process nodes in dependency-resolved order
+            foreach (var node in sortedNodes)
+            {
+                if (string.IsNullOrWhiteSpace(node.Line.LineCode)) continue;
+                if (node.Line.LineType == FLRTReportLineItem.LineItemType.Heading) continue;
+
+                decimal cyVal = 0m;
+                decimal pyVal = 0m;
+
+                switch (node.Line.LineType)
+                {
+                    case FLRTReportLineItem.LineItemType.Account:
+                        cyVal = CalculateAccountLine(node.Line, cyData, cyOpeningData, cyJanOpeningData, cyCumulativeData);
+                        pyVal = CalculateAccountLine(node.Line, pyData, pyOpeningData, pyJanOpeningData, pyCumulativeData);
+                        break;
+
+                    case FLRTReportLineItem.LineItemType.Subtotal:
+                        cyVal = CalculateSubtotal(node.Line.LineCode, node.DefinitionID, node.Prefix, _cyGlobal);
+                        pyVal = CalculateSubtotal(node.Line.LineCode, node.DefinitionID, node.Prefix, _pyGlobal);
+                        break;
+
+                    case FLRTReportLineItem.LineItemType.Calculated:
+                        cyVal = EvaluateFormula(node.Line.Formula, node.Prefix, knownPrefixes, _cyGlobal);
+                        pyVal = EvaluateFormula(node.Line.Formula, node.Prefix, knownPrefixes, _pyGlobal);
+                        break;
+                }
+
+                _cyGlobal[node.GlobalKey] = cyVal;
+                _pyGlobal[node.GlobalKey] = pyVal;
+
+                PXTrace.WriteInformation($"  [{node.Prefix}] {node.Line.LineCode,-30} CY={cyVal,15:#,##0.##}  PY={pyVal,15:#,##0.##}");
+            }
+
+            return BuildPlaceholderMap(allNodes);
+        }
+
+        // ─────────────────────────────────────────────────────────────────
+        // LEGACY SINGLE-DEFINITION ENTRY POINT (backward compatibility)
+        // ─────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Legacy single-definition entry point. Internally delegates to CalculateAll.
+        /// Output placeholder keys are now PREFIX_LINECODE_CY (e.g. BS_TOTAL_ASSETS_CY)
+        /// rather than LINECODE_CY. Existing Word templates must be updated accordingly.
+        /// </summary>
         public Dictionary<string, string> Calculate(
             int definitionID,
             FinancialApiData cyData,
             FinancialApiData pyData)
         {
-            _cyValues.Clear();
-            _pyValues.Clear();
-
-            // Load all line items for this definition, ordered by SortOrder
-            var lineItems = SelectFrom<FLRTReportLineItem>
-                .Where<FLRTReportLineItem.definitionID.IsEqual<@P.AsInt>>
-                .OrderBy<FLRTReportLineItem.sortOrder.Asc>
+            var def = SelectFrom<FLRTReportDefinition>
+                .Where<FLRTReportDefinition.definitionID.IsEqual<@P.AsInt>>
                 .View.Select(_graph, definitionID)
-                .RowCast<FLRTReportLineItem>()
-                .ToList();
+                .TopFirst;
 
-            if (!lineItems.Any())
+            if (def == null)
             {
-                PXTrace.WriteWarning($"ReportCalculationEngine: No line items found for DefinitionID {definitionID}.");
+                PXTrace.WriteWarning($"ReportCalculationEngine.Calculate: Definition {definitionID} not found.");
                 return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
-            PXTrace.WriteInformation($"ReportCalculationEngine: Processing {lineItems.Count} line items for DefinitionID {definitionID}.");
+            // Fallback prefix if not set: first 10 chars of DefinitionCD
+            string prefix = !string.IsNullOrWhiteSpace(def.DefinitionPrefix)
+                ? def.DefinitionPrefix
+                : def.DefinitionCD?.Length > 10
+                    ? def.DefinitionCD.Substring(0, 10).ToUpper()
+                    : def.DefinitionCD?.ToUpper() ?? "DEF";
 
-            // Process each line in SortOrder — order matters because subtotals depend on account lines
-            foreach (var line in lineItems)
+            var link = new DefinitionLink
             {
-                if (string.IsNullOrWhiteSpace(line.LineCode)) continue;
-                if (line.LineType == FLRTReportLineItem.LineItemType.Heading) continue;
+                DefinitionID = definitionID,
+                Prefix       = prefix,
+                Rounding     = RoundingSettings.FromDefinition(def)
+            };
 
-                decimal cyValue = 0m;
-                decimal pyValue = 0m;
+            return CalculateAll(new[] { link }, cyData, pyData, cyOpeningData: null, pyOpeningData: null);
+        }
 
-                switch (line.LineType)
+        // ─────────────────────────────────────────────────────────────────
+        // LINE ITEM LOADING
+        // ─────────────────────────────────────────────────────────────────
+
+        private List<LineNode> LoadAllLineItems(List<DefinitionLink> links)
+        {
+            var allNodes = new List<LineNode>();
+
+            foreach (var link in links)
+            {
+                if (string.IsNullOrWhiteSpace(link.Prefix))
+                {
+                    PXTrace.WriteWarning($"ReportCalculationEngine: DefinitionID {link.DefinitionID} has no prefix — skipping.");
+                    continue;
+                }
+
+                var lineItems = SelectFrom<FLRTReportLineItem>
+                    .Where<FLRTReportLineItem.definitionID.IsEqual<@P.AsInt>>
+                    .OrderBy<FLRTReportLineItem.sortOrder.Asc>
+                    .View.Select(_graph, link.DefinitionID)
+                    .RowCast<FLRTReportLineItem>()
+                    .ToList();
+
+                foreach (var line in lineItems)
+                {
+                    allNodes.Add(new LineNode
+                    {
+                        Line         = line,
+                        Prefix       = link.Prefix.ToUpper(),
+                        DefinitionID = link.DefinitionID,
+                        Rounding     = link.Rounding ?? new RoundingSettings()
+                    });
+                }
+
+                PXTrace.WriteInformation($"  Loaded {lineItems.Count} lines for definition {link.DefinitionID} (prefix: {link.Prefix})");
+            }
+
+            return allNodes;
+        }
+
+        // ─────────────────────────────────────────────────────────────────
+        // TOPOLOGICAL SORT (KAHN'S ALGORITHM)
+        // ─────────────────────────────────────────────────────────────────
+
+        private List<LineNode> BuildAndSort(List<LineNode> allNodes, HashSet<string> knownPrefixes)
+        {
+            // Map GlobalKey → node for fast lookup
+            var nodeMap = allNodes
+                .Where(n => !string.IsNullOrWhiteSpace(n.Line.LineCode))
+                .ToDictionary(n => n.GlobalKey, n => n, StringComparer.OrdinalIgnoreCase);
+
+            // Build dependency sets: deps[key] = set of keys that key depends on
+            var deps = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var node in nodeMap.Values)
+            {
+                string key = node.GlobalKey;
+                deps[key] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                switch (node.Line.LineType)
                 {
                     case FLRTReportLineItem.LineItemType.Account:
-                        cyValue = CalculateAccountLine(line, cyData);
-                        pyValue = CalculateAccountLine(line, pyData);
+                    case FLRTReportLineItem.LineItemType.Heading:
+                        // No calculation dependencies
                         break;
 
                     case FLRTReportLineItem.LineItemType.Subtotal:
-                        cyValue = CalculateSubtotal(line.LineCode, _cyValues);
-                        pyValue = CalculateSubtotal(line.LineCode, _pyValues);
+                        // Depends on all child lines (same definition)
+                        var childLines = SelectFrom<FLRTReportLineItem>
+                            .Where<FLRTReportLineItem.definitionID.IsEqual<@P.AsInt>
+                                .And<FLRTReportLineItem.parentLineCode.IsEqual<@P.AsString>>>
+                            .View.Select(_graph, node.DefinitionID, node.Line.LineCode)
+                            .RowCast<FLRTReportLineItem>()
+                            .ToList();
+
+                        foreach (var child in childLines)
+                        {
+                            if (!string.IsNullOrWhiteSpace(child.LineCode))
+                                deps[key].Add($"{node.Prefix}_{child.LineCode}".ToUpper());
+                        }
                         break;
 
                     case FLRTReportLineItem.LineItemType.Calculated:
-                        cyValue = EvaluateFormula(line.Formula, _cyValues);
-                        pyValue = EvaluateFormula(line.Formula, _pyValues);
+                        // Depends on all tokens resolved from the formula
+                        if (!string.IsNullOrWhiteSpace(node.Line.Formula))
+                        {
+                            var formulaDeps = ExtractFormulaDependencies(
+                                node.Line.Formula, node.Prefix, knownPrefixes);
+                            foreach (var dep in formulaDeps)
+                                deps[key].Add(dep);
+                        }
                         break;
                 }
-
-                _cyValues[line.LineCode] = cyValue;
-                _pyValues[line.LineCode] = pyValue;
-
-                PXTrace.WriteInformation($"  [{line.SortOrder:D4}] {line.LineCode,-30} CY={cyValue,15:#,##0.##}  PY={pyValue,15:#,##0.##}");
             }
 
-            // Build the final placeholder dictionary
-            return BuildPlaceholderMap(lineItems);
+            // Kahn's algorithm
+            // inDegree[key]  = number of unresolved dependencies for this node
+            // dependents[key] = reverse edges: nodes that become unblocked when key is processed
+            var inDegree   = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var dependents = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            // Build inDegree and reverse-edge (dependents) map in one pass
+            foreach (var kvp in deps)
+            {
+                string key = kvp.Key;
+                int count = 0;
+
+                foreach (string dep in kvp.Value)
+                {
+                    if (!nodeMap.ContainsKey(dep)) continue; // ignore refs to unknown nodes
+
+                    count++;
+
+                    if (!dependents.ContainsKey(dep))
+                        dependents[dep] = new List<string>();
+                    dependents[dep].Add(key);
+                }
+
+                inDegree[key] = count;
+            }
+
+            var queue = new Queue<string>();
+            foreach (var kvp in inDegree)
+            {
+                if (kvp.Value == 0)
+                    queue.Enqueue(kvp.Key);
+            }
+
+            var sortedKeys = new List<string>();
+            while (queue.Count > 0)
+            {
+                string key = queue.Dequeue();
+                sortedKeys.Add(key);
+
+                if (dependents.TryGetValue(key, out var depList))
+                {
+                    foreach (string dependent in depList)
+                    {
+                        inDegree[dependent]--;
+                        if (inDegree[dependent] == 0)
+                            queue.Enqueue(dependent);
+                    }
+                }
+            }
+
+            // Cycle detection
+            if (sortedKeys.Count < nodeMap.Count)
+            {
+                var cycleNodes = inDegree
+                    .Where(kv => kv.Value > 0)
+                    .Select(kv => kv.Key)
+                    .ToList();
+
+                throw new PXException(
+                    Messages.CircularDependencyDetected,
+                    string.Join(", ", cycleNodes));
+            }
+
+            // Return nodes in resolved order; nodes not in deps (HEADINGs, invalid) go last
+            var sortedNodeList = sortedKeys
+                .Where(k => nodeMap.ContainsKey(k))
+                .Select(k => nodeMap[k])
+                .ToList();
+
+            // Append any nodes that weren't in the dep graph (HEADINGs etc.)
+            var sortedSet = new HashSet<string>(sortedKeys, StringComparer.OrdinalIgnoreCase);
+            foreach (var node in allNodes)
+            {
+                if (!string.IsNullOrWhiteSpace(node.Line.LineCode) && !sortedSet.Contains(node.GlobalKey))
+                    sortedNodeList.Add(node);
+            }
+
+            return sortedNodeList;
+        }
+
+        // ─────────────────────────────────────────────────────────────────
+        // FORMULA DEPENDENCY EXTRACTION
+        // ─────────────────────────────────────────────────────────────────
+
+        private HashSet<string> ExtractFormulaDependencies(
+            string formula, string currentPrefix, HashSet<string> knownPrefixes)
+        {
+            var deps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var tokens = TokenizeFormula(formula);
+
+            foreach (string token in tokens)
+            {
+                if (decimal.TryParse(token, out _)) continue;
+                if ("+-*/()".Contains(token)) continue;
+                if (string.IsNullOrWhiteSpace(token)) continue;
+
+                string resolved = ResolveToken(token, currentPrefix, knownPrefixes);
+                deps.Add(resolved.ToUpper());
+            }
+
+            return deps;
+        }
+
+        // ─────────────────────────────────────────────────────────────────
+        // TOKEN RESOLUTION (explicit vs. implicit prefix)
+        // ─────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Resolves a formula token to its global dictionary key (PREFIX_LINECODE).
+        ///
+        /// Explicit: token starts with a known prefix + "_"
+        ///   → "BS_TOTAL_ASSETS" in any formula → resolved as "BS_TOTAL_ASSETS"
+        ///
+        /// Implicit: no known prefix detected
+        ///   → "TOTAL_ASSETS" in a CF formula → resolved as "CF_TOTAL_ASSETS"
+        /// </summary>
+        private string ResolveToken(string token, string currentPrefix, HashSet<string> knownPrefixes)
+        {
+            foreach (string prefix in knownPrefixes)
+            {
+                if (token.StartsWith(prefix + "_", StringComparison.OrdinalIgnoreCase))
+                    return token.ToUpper(); // already fully qualified
+            }
+
+            // Implicit: belongs to own definition
+            return $"{currentPrefix}_{token}".ToUpper();
         }
 
         // ─────────────────────────────────────────────────────────────────
         // ACCOUNT LINE CALCULATION
         // ─────────────────────────────────────────────────────────────────
 
-        private decimal CalculateAccountLine(FLRTReportLineItem line, FinancialApiData data)
+        private decimal CalculateAccountLine(FLRTReportLineItem line, FinancialApiData data, FinancialApiData openingData = null, FinancialApiData janOpeningData = null, FinancialApiData cumulativeData = null)
         {
             if (data == null) return 0m;
             if (string.IsNullOrWhiteSpace(line.AccountFrom) || string.IsNullOrWhiteSpace(line.AccountTo))
                 return 0m;
 
-            // When any per-line dimension filter is set, use the raw DetailRows so we can
-            // match on Subaccount / BranchID / OrganizationID per row.
             bool hasFilter = !string.IsNullOrWhiteSpace(line.SubaccountFilter)
                           || !string.IsNullOrWhiteSpace(line.BranchFilter)
                           || !string.IsNullOrWhiteSpace(line.OrganizationFilter)
                           || !string.IsNullOrWhiteSpace(line.LedgerFilter);
 
             if (hasFilter && data.DetailRows != null && data.DetailRows.Count > 0)
-                return CalculateAccountLineFromDetail(line, data.DetailRows);
+                return CalculateAccountLineFromDetail(line, data.DetailRows, openingData?.DetailRows, janOpeningData?.DetailRows, cumulativeData?.DetailRows);
 
-            // ── Default path: aggregated AccountData (same as before) ──
-            if (data.AccountData == null) return 0m;
+            bool isBeginning        = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.Beginning,        StringComparison.OrdinalIgnoreCase);
+            bool isJanuaryBeginning = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.JanuaryBeginning, StringComparison.OrdinalIgnoreCase);
+            bool isDebit    = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.Debit,    StringComparison.OrdinalIgnoreCase);
+            bool isCredit   = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.Credit,   StringComparison.OrdinalIgnoreCase);
+            bool isMovement = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.Movement, StringComparison.OrdinalIgnoreCase);
+
+            // For Debit/Credit/Movement use the year-to-date cumulative data set (Jan–Dec range)
+            // so that transactions from any month are captured, not just the year-end period's values.
+            bool useCumulative = (isDebit || isCredit || isMovement) && cumulativeData?.AccountData != null;
+            var sourceData = useCumulative ? cumulativeData : data;
+
+            if (sourceData.AccountData == null) return 0m;
 
             decimal total = 0m;
             int matched = 0;
 
-            foreach (var kvp in data.AccountData)
+            foreach (var kvp in sourceData.AccountData)
             {
                 string accountCode = kvp.Key;
                 FinancialPeriodData periodData = kvp.Value;
 
-                // Filter by account range
                 if (!IsAccountInRange(accountCode, line.AccountFrom, line.AccountTo))
                     continue;
 
-                // Filter by account type if specified (uses the Type field from the GI)
                 if (!string.IsNullOrWhiteSpace(line.AccountTypeFilter)
                     && !string.Equals(periodData.AccountType, line.AccountTypeFilter, StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                // Get the raw balance for the specified balance type
-                decimal rawValue = GetBalanceByType(periodData, line.BalanceType);
+                decimal rawValue;
+                if (isBeginning && openingData?.AccountData != null)
+                {
+                    // Opening balance = EndingBalance of the prior fiscal-year-end period.
+                    // Works for any fiscal year end month.
+                    rawValue = openingData.AccountData.TryGetValue(accountCode, out FinancialPeriodData openingPeriod)
+                        ? openingPeriod.EndingBalance
+                        : 0m;
+                }
+                else if (isJanuaryBeginning && janOpeningData?.AccountData != null)
+                {
+                    // Opening balance = BeginningBalance of period 01-{Year}.
+                    // Best suited for calendar-year (Jan–Dec) fiscal periods.
+                    rawValue = janOpeningData.AccountData.TryGetValue(accountCode, out FinancialPeriodData janPeriod)
+                        ? janPeriod.BeginningBalance
+                        : 0m;
+                }
+                else
+                {
+                    // For Debit/Credit/Movement, periodData is already from cumulativeData (full-year).
+                    // For Ending/Beginning fallback, periodData is from the single year-end period.
+                    rawValue = GetBalanceByType(periodData, line.BalanceType);
+                }
 
-                // Apply sign normalization based on account type from GI
                 decimal signCorrected = ApplyAccountTypeSign(rawValue, periodData.AccountType);
-
-                // Apply the line-level sign rule (FLIP allows accountant to override)
-                decimal finalValue = line.SignRule == FLRTReportLineItem.SignRuleValue.Flip
+                decimal finalValue  = line.SignRule == FLRTReportLineItem.SignRuleValue.Flip
                     ? signCorrected * -1
                     : signCorrected;
 
@@ -173,19 +548,25 @@ namespace FinancialReport.Services
             return total;
         }
 
-        /// <summary>
-        /// Filtered variant of account calculation — iterates the per-row DetailRows
-        /// and applies optional Subaccount / Branch / Organization filters.
-        /// </summary>
-        private decimal CalculateAccountLineFromDetail(FLRTReportLineItem line, List<FinancialPeriodData> detailRows)
+        private decimal CalculateAccountLineFromDetail(FLRTReportLineItem line, List<FinancialPeriodData> detailRows, List<FinancialPeriodData> openingDetailRows = null, List<FinancialPeriodData> janOpeningDetailRows = null, List<FinancialPeriodData> cumulativeDetailRows = null)
         {
             decimal total = 0m;
             int matched = 0;
 
-            foreach (var row in detailRows)
+            bool isBeginning        = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.Beginning,        StringComparison.OrdinalIgnoreCase);
+            bool isJanuaryBeginning = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.JanuaryBeginning, StringComparison.OrdinalIgnoreCase);
+            bool isDebit    = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.Debit,    StringComparison.OrdinalIgnoreCase);
+            bool isCredit   = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.Credit,   StringComparison.OrdinalIgnoreCase);
+            bool isMovement = string.Equals(line.BalanceType, FLRTReportLineItem.BalanceTypeValue.Movement, StringComparison.OrdinalIgnoreCase);
+
+            // For Debit/Credit/Movement use year-to-date cumulative rows (full-year range)
+            // so transactions from any month are captured, not just the year-end period.
+            bool useCumulative = (isDebit || isCredit || isMovement) && cumulativeDetailRows != null && cumulativeDetailRows.Count > 0;
+            var sourceRows = useCumulative ? cumulativeDetailRows : detailRows;
+
+            foreach (var row in sourceRows)
             {
-                if (!IsAccountInRange(row.Account, line.AccountFrom, line.AccountTo))
-                    continue;
+                if (!IsAccountInRange(row.Account, line.AccountFrom, line.AccountTo)) continue;
 
                 if (!string.IsNullOrWhiteSpace(line.AccountTypeFilter)
                     && !string.Equals(row.AccountType, line.AccountTypeFilter, StringComparison.OrdinalIgnoreCase))
@@ -207,7 +588,35 @@ namespace FinancialReport.Services
                     && !string.Equals(row.Ledger, line.LedgerFilter, StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                decimal rawValue      = GetBalanceByType(row, line.BalanceType);
+                decimal rawValue;
+                if (isBeginning && openingDetailRows != null)
+                {
+                    // Opening balance = EndingBalance of the prior fiscal-year-end period for the same dimension combination.
+                    var openingRow = openingDetailRows.FirstOrDefault(r =>
+                        string.Equals(r.Account,         row.Account,         StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(r.Subaccount,      row.Subaccount,      StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(r.BranchID,        row.BranchID,        StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(r.OrganizationID,  row.OrganizationID,  StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(r.Ledger,          row.Ledger,          StringComparison.OrdinalIgnoreCase));
+                    rawValue = openingRow != null ? openingRow.EndingBalance : 0m;
+                }
+                else if (isJanuaryBeginning && janOpeningDetailRows != null)
+                {
+                    // Opening balance = BeginningBalance of period 01-{Year} for the same dimension combination.
+                    var janRow = janOpeningDetailRows.FirstOrDefault(r =>
+                        string.Equals(r.Account,         row.Account,         StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(r.Subaccount,      row.Subaccount,      StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(r.BranchID,        row.BranchID,        StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(r.OrganizationID,  row.OrganizationID,  StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(r.Ledger,          row.Ledger,          StringComparison.OrdinalIgnoreCase));
+                    rawValue = janRow != null ? janRow.BeginningBalance : 0m;
+                }
+                else
+                {
+                    // For Debit/Credit/Movement, row is already from cumulativeDetailRows (full-year).
+                    rawValue = GetBalanceByType(row, line.BalanceType);
+                }
+
                 decimal signCorrected = ApplyAccountTypeSign(rawValue, row.AccountType);
                 decimal finalValue    = line.SignRule == FLRTReportLineItem.SignRuleValue.Flip
                                         ? signCorrected * -1
@@ -217,12 +626,12 @@ namespace FinancialReport.Services
                 matched++;
             }
 
-            PXTrace.WriteInformation($"    Account range {line.AccountFrom}:{line.AccountTo} [filtered] matched {matched} of {detailRows.Count} detail rows → {total:#,##0.##}");
+            PXTrace.WriteInformation($"    Account range {line.AccountFrom}:{line.AccountTo} [filtered] matched {matched} of {sourceRows.Count} detail rows → {total:#,##0.##}");
+
             if (matched == 0)
             {
-                // Log filter values and a sample of what's in the data for debugging
                 PXTrace.WriteWarning($"    Filters: Sub='{line.SubaccountFilter}' Branch='{line.BranchFilter}' Org='{line.OrganizationFilter}' Ledger='{line.LedgerFilter}'");
-                var inRange = detailRows.Where(r => IsAccountInRange(r.Account, line.AccountFrom, line.AccountTo)).Take(3).ToList();
+                var inRange = sourceRows.Where(r => IsAccountInRange(r.Account, line.AccountFrom, line.AccountTo)).Take(3).ToList();
                 foreach (var r in inRange)
                     PXTrace.WriteWarning($"    Sample row: Acct={r.Account} Sub='{r.Subaccount}' Branch='{r.BranchID}' Org='{r.OrganizationID}' Ledger='{r.Ledger}' EndBal={r.EndingBalance}");
             }
@@ -232,23 +641,19 @@ namespace FinancialReport.Services
 
         // ─────────────────────────────────────────────────────────────────
         // SIGN NORMALIZATION
-        // Converts raw GL credit-normal balances to presentation-positive values
-        // based on the AccountType returned by the TrialBalance GI.
         // ─────────────────────────────────────────────────────────────────
 
         private decimal ApplyAccountTypeSign(decimal rawValue, string accountType)
         {
-            // Credit-normal accounts store natural balances as negatives in the GL.
-            // Flip them so they appear positive on the financial statement.
             switch (accountType?.Trim())
             {
-                case FLRTReportLineItem.AccountTypeValue.Liability: // L
-                case FLRTReportLineItem.AccountTypeValue.Income:    // I
-                case FLRTReportLineItem.AccountTypeValue.Equity:    // Q
+                case FLRTReportLineItem.AccountTypeValue.Liability:
+                case FLRTReportLineItem.AccountTypeValue.Income:
+                case FLRTReportLineItem.AccountTypeValue.Equity:
                     return rawValue * -1;
 
-                case FLRTReportLineItem.AccountTypeValue.Asset:     // A
-                case FLRTReportLineItem.AccountTypeValue.Expense:   // E
+                case FLRTReportLineItem.AccountTypeValue.Asset:
+                case FLRTReportLineItem.AccountTypeValue.Expense:
                 default:
                     return rawValue;
             }
@@ -274,22 +679,30 @@ namespace FinancialReport.Services
 
         // ─────────────────────────────────────────────────────────────────
         // SUBTOTAL CALCULATION
-        // Sums all lines that declared this LineCode as their ParentLineCode
+        // Scoped to the same definition (by DefinitionID + Prefix)
+        // Looks up child values from the global dictionary
         // ─────────────────────────────────────────────────────────────────
 
-        private decimal CalculateSubtotal(string subtotalLineCode, Dictionary<string, decimal> values)
+        private decimal CalculateSubtotal(
+            string subtotalLineCode,
+            int definitionID,
+            string prefix,
+            Dictionary<string, decimal> globalValues)
         {
-            // Find all line items in this definition that belong to this subtotal group
+            // Child lines are always within the same definition
             var childLines = SelectFrom<FLRTReportLineItem>
-                .Where<FLRTReportLineItem.parentLineCode.IsEqual<@P.AsString>>
-                .View.Select(_graph, subtotalLineCode)
+                .Where<FLRTReportLineItem.definitionID.IsEqual<@P.AsInt>
+                    .And<FLRTReportLineItem.parentLineCode.IsEqual<@P.AsString>>>
+                .View.Select(_graph, definitionID, subtotalLineCode)
                 .RowCast<FLRTReportLineItem>()
                 .ToList();
 
             decimal total = 0m;
             foreach (var child in childLines)
             {
-                if (values.TryGetValue(child.LineCode, out decimal childValue))
+                if (string.IsNullOrWhiteSpace(child.LineCode)) continue;
+                string childKey = $"{prefix}_{child.LineCode}".ToUpper();
+                if (globalValues.TryGetValue(childKey, out decimal childValue))
                     total += childValue;
             }
 
@@ -298,21 +711,22 @@ namespace FinancialReport.Services
 
         // ─────────────────────────────────────────────────────────────────
         // FORMULA EVALUATOR
-        // Handles expressions like: REVENUE - TOTAL_EXPENSES + OTHER_INCOME
-        // Supports: +, -, *, / operators and parentheses
-        // Operands must be LineCodes already calculated (earlier SortOrder)
+        // Resolves tokens as PREFIX_LINECODE, supports both explicit and
+        // implicit prefix syntax.
         // ─────────────────────────────────────────────────────────────────
 
-        private decimal EvaluateFormula(string formula, Dictionary<string, decimal> values)
+        private decimal EvaluateFormula(
+            string formula,
+            string currentPrefix,
+            HashSet<string> knownPrefixes,
+            Dictionary<string, decimal> globalValues)
         {
             if (string.IsNullOrWhiteSpace(formula)) return 0m;
 
             try
             {
-                // Tokenize: split on operators while keeping them
-                // Handles: REVENUE - TOTAL_EXPENSES * 1.5 + (OTHER_INCOME - ADJUSTMENTS)
                 var tokens = TokenizeFormula(formula);
-                return EvaluateTokens(tokens, values);
+                return EvaluateTokens(tokens, currentPrefix, knownPrefixes, globalValues);
             }
             catch (Exception ex)
             {
@@ -323,45 +737,51 @@ namespace FinancialReport.Services
 
         private List<string> TokenizeFormula(string formula)
         {
-            // Matches line codes (alphanumeric + underscore), numbers, operators, and parentheses
             var tokenRegex = new Regex(@"([A-Z][A-Z0-9_]*)|([\d]+\.?[\d]*)|([\+\-\*\/\(\)])", RegexOptions.IgnoreCase);
             var tokens = new List<string>();
-
             foreach (Match m in tokenRegex.Matches(formula.Trim()))
                 tokens.Add(m.Value);
-
             return tokens;
         }
 
-        // Recursive descent parser: handles operator precedence and parentheses
-        private decimal EvaluateTokens(List<string> tokens, Dictionary<string, decimal> values)
+        private decimal EvaluateTokens(
+            List<string> tokens,
+            string currentPrefix,
+            HashSet<string> knownPrefixes,
+            Dictionary<string, decimal> globalValues)
         {
             int pos = 0;
-            return ParseExpression(tokens, ref pos, values);
+            return ParseExpression(tokens, ref pos, currentPrefix, knownPrefixes, globalValues);
         }
 
-        private decimal ParseExpression(List<string> tokens, ref int pos, Dictionary<string, decimal> values)
+        private decimal ParseExpression(
+            List<string> tokens, ref int pos,
+            string currentPrefix, HashSet<string> knownPrefixes,
+            Dictionary<string, decimal> globalValues)
         {
-            decimal result = ParseTerm(tokens, ref pos, values);
+            decimal result = ParseTerm(tokens, ref pos, currentPrefix, knownPrefixes, globalValues);
 
             while (pos < tokens.Count && (tokens[pos] == "+" || tokens[pos] == "-"))
             {
                 string op = tokens[pos++];
-                decimal right = ParseTerm(tokens, ref pos, values);
+                decimal right = ParseTerm(tokens, ref pos, currentPrefix, knownPrefixes, globalValues);
                 result = op == "+" ? result + right : result - right;
             }
 
             return result;
         }
 
-        private decimal ParseTerm(List<string> tokens, ref int pos, Dictionary<string, decimal> values)
+        private decimal ParseTerm(
+            List<string> tokens, ref int pos,
+            string currentPrefix, HashSet<string> knownPrefixes,
+            Dictionary<string, decimal> globalValues)
         {
-            decimal result = ParseFactor(tokens, ref pos, values);
+            decimal result = ParseFactor(tokens, ref pos, currentPrefix, knownPrefixes, globalValues);
 
             while (pos < tokens.Count && (tokens[pos] == "*" || tokens[pos] == "/"))
             {
                 string op = tokens[pos++];
-                decimal right = ParseFactor(tokens, ref pos, values);
+                decimal right = ParseFactor(tokens, ref pos, currentPrefix, knownPrefixes, globalValues);
                 if (op == "/" && right != 0)
                     result = result / right;
                 else if (op == "*")
@@ -371,48 +791,46 @@ namespace FinancialReport.Services
             return result;
         }
 
-        private decimal ParseFactor(List<string> tokens, ref int pos, Dictionary<string, decimal> values)
+        private decimal ParseFactor(
+            List<string> tokens, ref int pos,
+            string currentPrefix, HashSet<string> knownPrefixes,
+            Dictionary<string, decimal> globalValues)
         {
             if (pos >= tokens.Count) return 0m;
 
             string token = tokens[pos];
 
-            // Parenthesized sub-expression
             if (token == "(")
             {
-                pos++; // consume "("
-                decimal inner = ParseExpression(tokens, ref pos, values);
+                pos++;
+                decimal inner = ParseExpression(tokens, ref pos, currentPrefix, knownPrefixes, globalValues);
                 if (pos < tokens.Count && tokens[pos] == ")")
-                    pos++; // consume ")"
+                    pos++;
                 return inner;
             }
 
-            // Unary minus
             if (token == "-")
             {
                 pos++;
-                return -ParseFactor(tokens, ref pos, values);
+                return -ParseFactor(tokens, ref pos, currentPrefix, knownPrefixes, globalValues);
             }
 
             pos++;
 
-            // Numeric literal
             if (decimal.TryParse(token, out decimal numericValue))
                 return numericValue;
 
-            // LineCode reference — look up already-calculated value
-            string lineCode = token.ToUpper();
-            if (values.TryGetValue(lineCode, out decimal lineValue))
+            // Resolve token to global key and look up
+            string globalKey = ResolveToken(token, currentPrefix, knownPrefixes);
+            if (globalValues.TryGetValue(globalKey, out decimal lineValue))
                 return lineValue;
 
-            PXTrace.WriteWarning($"ReportCalculationEngine: Formula references unknown LineCode '{token}'. " +
-                                  "Ensure it is defined earlier in SortOrder. Defaulting to 0.");
+            PXTrace.WriteWarning($"ReportCalculationEngine: Formula references unknown key '{globalKey}' (token: '{token}'). Defaulting to 0.");
             return 0m;
         }
 
         // ─────────────────────────────────────────────────────────────────
         // ACCOUNT RANGE COMPARISON
-        // Reuses the same smart alphanumeric comparison from FinancialDataService
         // ─────────────────────────────────────────────────────────────────
 
         private bool IsAccountInRange(string account, string from, string to)
@@ -469,60 +887,59 @@ namespace FinancialReport.Services
 
         // ─────────────────────────────────────────────────────────────────
         // BUILD PLACEHOLDER MAP
-        // Converts the internal decimal values into formatted strings
-        // keyed by {{LINECODE_CY}} / {{LINECODE_PY}} placeholder names
+        // Keys: PREFIX_LINECODE_CY / PREFIX_LINECODE_PY
+        // Values: formatted strings (per-definition rounding applied)
         // ─────────────────────────────────────────────────────────────────
 
-        private Dictionary<string, string> BuildPlaceholderMap(List<FLRTReportLineItem> lineItems)
+        private Dictionary<string, string> BuildPlaceholderMap(List<LineNode> allNodes)
         {
             var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var line in lineItems)
+            foreach (var node in allNodes)
             {
-                if (string.IsNullOrWhiteSpace(line.LineCode)) continue;
+                if (string.IsNullOrWhiteSpace(node.Line.LineCode)) continue;
 
-                string cyKey = $"{line.LineCode}_{Constants.CurrentYearSuffix}";
-                string pyKey = $"{line.LineCode}_{Constants.PreviousYearSuffix}";
+                string cyKey = $"{node.Prefix}_{node.Line.LineCode}_{Constants.CurrentYearSuffix}";
+                string pyKey = $"{node.Prefix}_{node.Line.LineCode}_{Constants.PreviousYearSuffix}";
 
-                // Heading lines and non-visible lines get empty string (not "0")
-                if (line.LineType == FLRTReportLineItem.LineItemType.Heading || line.IsVisible == false)
+                if (node.Line.LineType == FLRTReportLineItem.LineItemType.Heading || node.Line.IsVisible == false)
                 {
                     map[cyKey] = string.Empty;
                     map[pyKey] = string.Empty;
                     continue;
                 }
 
-                decimal cyVal = _cyValues.TryGetValue(line.LineCode, out decimal cy) ? cy : 0m;
-                decimal pyVal = _pyValues.TryGetValue(line.LineCode, out decimal py) ? py : 0m;
+                decimal cyVal = _cyGlobal.TryGetValue(node.GlobalKey, out decimal cy) ? cy : 0m;
+                decimal pyVal = _pyGlobal.TryGetValue(node.GlobalKey, out decimal py) ? py : 0m;
 
-                map[cyKey] = FormatFinancialValue(cyVal);
-                map[pyKey] = FormatFinancialValue(pyVal);
+                map[cyKey] = FormatFinancialValue(cyVal, node.Rounding);
+                map[pyKey] = FormatFinancialValue(pyVal, node.Rounding);
             }
 
             return map;
         }
 
-        /// <summary>
-        /// Formats a decimal for financial report presentation.
-        /// Applies rounding level (Units/Thousands/Millions) and decimal places.
-        /// Positive values: "1,234,567"
-        /// Negative values: "(1,234,567)"  — accounting bracket notation
-        /// Zero: "-"  (dash, standard financial statement practice)
-        /// </summary>
-        private string FormatFinancialValue(decimal value)
+        // ─────────────────────────────────────────────────────────────────
+        // VALUE FORMATTING
+        // ─────────────────────────────────────────────────────────────────
+
+        private string FormatFinancialValue(decimal value, RoundingSettings rounding = null)
         {
-            decimal scaled = ApplyRounding(value);
+            rounding = rounding ?? _rounding;
+            decimal scaled = ApplyRounding(value, rounding);
 
             if (scaled == 0m) return "-";
 
-            string format = BuildFormatString();
+            string format = BuildFormatString(rounding);
             if (scaled < 0m) return $"({Math.Abs(scaled).ToString(format)})";
             return scaled.ToString(format);
         }
 
-        private decimal ApplyRounding(decimal value)
+        private decimal ApplyRounding(decimal value, RoundingSettings rounding = null)
         {
-            switch (_rounding.RoundingLevel)
+            rounding = rounding ?? _rounding;
+
+            switch (rounding.RoundingLevel)
             {
                 case FLRTReportDefinition.RoundingLevelType.Thousands:
                     value = value / 1000m;
@@ -532,14 +949,15 @@ namespace FinancialReport.Services
                     break;
             }
 
-            return Math.Round(value, _rounding.DecimalPlaces, MidpointRounding.AwayFromZero);
+            return Math.Round(value, rounding.DecimalPlaces, MidpointRounding.AwayFromZero);
         }
 
-        private string BuildFormatString()
+        private string BuildFormatString(RoundingSettings rounding = null)
         {
-            if (_rounding.DecimalPlaces <= 0)
+            rounding = rounding ?? _rounding;
+            if (rounding.DecimalPlaces <= 0)
                 return "#,##0";
-            return "#,##0." + new string('0', _rounding.DecimalPlaces);
+            return "#,##0." + new string('0', rounding.DecimalPlaces);
         }
     }
 }

--- a/FinancialReport/Services/ReportGenerationService.cs
+++ b/FinancialReport/Services/ReportGenerationService.cs
@@ -51,12 +51,42 @@ namespace FinancialReport.Services
                 int? companyID = _graph.GetCompanyIDFromDB(_currentRecord.ReportID);
                 string tenantName = _graph.MapCompanyIDToTenantName(companyID);
 
-                // 1b. Load Report Definition for GI/column/rounding config (if linked)
+                // 1b. Load Report Definitions — multi-definition (new) or single legacy fallback
                 GIColumnMapping columnMapping = null;
-                RoundingSettings roundingSettings = null;
+                var definitionLinks = new List<ReportCalculationEngine.DefinitionLink>();
 
-                if (_currentRecord.DefinitionID != null)
+                // Check for linked definitions first (multi-def path)
+                var linkedDefs = SelectFrom<FLRTReportDefinitionLink>
+                    .InnerJoin<FLRTReportDefinition>
+                        .On<FLRTReportDefinition.definitionID.IsEqual<FLRTReportDefinitionLink.definitionID>>
+                    .Where<FLRTReportDefinitionLink.reportID.IsEqual<@P.AsInt>>
+                    .OrderBy<FLRTReportDefinitionLink.displayOrder.Asc>
+                    .View.Select(_graph, _currentRecord.ReportID)
+                    .Cast<PXResult<FLRTReportDefinitionLink, FLRTReportDefinition>>()
+                    .ToList();
+
+                if (linkedDefs.Any())
                 {
+                    // Use the first definition's GI mapping for GL data fetching
+                    var firstDef = linkedDefs.First().GetItem<FLRTReportDefinition>();
+                    columnMapping = GIColumnMapping.FromDefinition(firstDef);
+
+                    foreach (var result in linkedDefs)
+                    {
+                        var def = result.GetItem<FLRTReportDefinition>();
+                        definitionLinks.Add(new ReportCalculationEngine.DefinitionLink
+                        {
+                            DefinitionID = def.DefinitionID.Value,
+                            Prefix       = def.DefinitionPrefix,
+                            Rounding     = RoundingSettings.FromDefinition(def)
+                        });
+                    }
+
+                    PXTrace.WriteInformation($"Multi-definition report: {definitionLinks.Count} definition(s) linked — prefixes: [{string.Join(", ", definitionLinks.Select(d => d.Prefix))}]");
+                }
+                else if (_currentRecord.DefinitionID != null)
+                {
+                    // Legacy single-definition fallback
                     var reportDef = SelectFrom<FLRTReportDefinition>
                         .Where<FLRTReportDefinition.definitionID.IsEqual<@P.AsInt>>
                         .View.Select(_graph, _currentRecord.DefinitionID)
@@ -65,8 +95,14 @@ namespace FinancialReport.Services
                     if (reportDef != null)
                     {
                         columnMapping = GIColumnMapping.FromDefinition(reportDef);
-                        roundingSettings = RoundingSettings.FromDefinition(reportDef);
-                        PXTrace.WriteInformation($"Report Definition '{reportDef.DefinitionCD}': GI={columnMapping.GIName}, Rounding={roundingSettings.RoundingLevel}/{roundingSettings.DecimalPlaces}dp");
+                        var rounding  = RoundingSettings.FromDefinition(reportDef);
+                        definitionLinks.Add(new ReportCalculationEngine.DefinitionLink
+                        {
+                            DefinitionID = reportDef.DefinitionID.Value,
+                            Prefix       = reportDef.DefinitionPrefix,
+                            Rounding     = rounding
+                        });
+                        PXTrace.WriteInformation($"Legacy single definition '{reportDef.DefinitionCD}' (prefix: {reportDef.DefinitionPrefix}): GI={columnMapping.GIName}, Rounding={rounding.RoundingLevel}/{rounding.DecimalPlaces}dp");
                     }
                 }
 
@@ -104,9 +140,27 @@ namespace FinancialReport.Services
                 string currYear = _currentRecord.CurrYear ?? DateTime.Now.ToString("yyyy");
                 string selectedMonth = _currentRecord.FinancialMonth ?? "12";
                 int currYearInt = int.TryParse(currYear, out int parsedYear) ? parsedYear : DateTime.Now.Year;
+                int selectedMonthInt = int.TryParse(selectedMonth, out int parsedMonth) ? parsedMonth : 12;
                 string prevYear = (currYearInt - 1).ToString();
+                string prevYearPrior = (currYearInt - 2).ToString();
                 string selectedPeriod = $"{selectedMonth}{currYear}";
                 string prevYearPeriod = $"{selectedMonth}{prevYear}";
+                string prevYearPriorPeriod = $"{selectedMonth}{prevYearPrior}";
+
+                // Compute the fiscal year start period for cumulative (Debit/Credit/Movement) fetches.
+                // The fiscal year starts on the month immediately after the financial year-end month.
+                //   e.g. year-end = April (04) → fiscal start = May (05)
+                //   e.g. year-end = December (12) → fiscal start = January (01) of same calendar year
+                int fiscalStartMonthInt = (selectedMonthInt % 12) + 1;
+                string fiscalStartMonth = fiscalStartMonthInt.ToString("D2");
+                // When the fiscal start month is AFTER the year-end month numerically, the fiscal year
+                // crosses a calendar year boundary and the start falls in the PRIOR calendar year.
+                int cyCumulativeStartYearInt = fiscalStartMonthInt > selectedMonthInt ? currYearInt - 1 : currYearInt;
+                string cyCumulativeStart = $"{fiscalStartMonth}{cyCumulativeStartYearInt}";
+                string pyCumulativeStart = $"{fiscalStartMonth}{cyCumulativeStartYearInt - 1}";
+                string pyCumulativeEnd   = prevYearPeriod; // $"{selectedMonth}{prevYear}"
+
+                PXTrace.WriteInformation($"Fiscal year: {cyCumulativeStart} → {selectedPeriod} (CY), {pyCumulativeStart} → {pyCumulativeEnd} (PY)");
 
                 // 6. Fetch all required data from the API in parallel
                 var dataFetchTasks = new[]
@@ -115,8 +169,10 @@ namespace FinancialReport.Services
             Task.Run(() => localDataService.FetchAllApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, prevYearPeriod)),
             Task.Run(() => localDataService.FetchJanuaryBeginningBalance(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, prevYear)),
             Task.Run(() => localDataService.FetchJanuaryBeginningBalance(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, currYear)),
-            Task.Run(() => localDataService.FetchRangeApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, $"01{currYear}", selectedPeriod)),
-            Task.Run(() => localDataService.FetchRangeApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, $"01{prevYear}", $"12{prevYear}"))
+            Task.Run(() => localDataService.FetchRangeApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, cyCumulativeStart, selectedPeriod)),
+            Task.Run(() => localDataService.FetchRangeApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, pyCumulativeStart, pyCumulativeEnd)),
+            // [6] Opening balance data for PY: year-end of (currYear-2) → EndingBalance = PY fiscal-year opening
+            Task.Run(() => localDataService.FetchAllApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, prevYearPriorPeriod))
         };
 
                 var results = Task.WhenAll(dataFetchTasks).Result;
@@ -126,8 +182,11 @@ namespace FinancialReport.Services
                 var januaryBeginningDataCY = results[3];
                 var cumulativeCYData = results[4];
                 var cumulativePYData = results[5];
+                // prevYearData.EndingBalance     = CY fiscal-year opening balance
+                // prevYearPriorData.EndingBalance = PY fiscal-year opening balance
+                var prevYearPriorData = results[6];
 
-                PXTrace.WriteInformation("📊 6 API calls completed - starting optimized placeholder processing");
+                PXTrace.WriteInformation("📊 7 API calls completed - starting optimized placeholder processing");
 
                 // 7. Set up user settings for analysis
                 var userSettings = new UserSettings
@@ -156,18 +215,24 @@ namespace FinancialReport.Services
                 // 11. Combine all placeholder values
                 var finalPlaceholders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-                // ── NEW: If a Report Definition is linked, run the calculation engine first.
-                // The engine produces sign-corrected, pre-calculated values for every report
-                // line (ACCOUNT, SUBTOTAL, CALCULATED) keyed as LINECODE_CY / LINECODE_PY.
-                // Engine values take priority — they are the "right" answer.
-                if (_currentRecord.DefinitionID != null)
+                // ── Run ReportCalculationEngine for all linked definitions.
+                // Produces PREFIX_LINECODE_CY / PREFIX_LINECODE_PY placeholders.
+                // Cross-definition formulas are resolved via topological sort.
+                // Engine values take priority over raw account placeholders.
+                if (definitionLinks.Any())
                 {
-                    PXTrace.WriteInformation($"Report Definition ID {_currentRecord.DefinitionID} found — running ReportCalculationEngine.");
-                    var engine = new ReportCalculationEngine(_graph, roundingSettings);
-                    var enginePlaceholders = engine.Calculate(
-                        _currentRecord.DefinitionID.Value,
+                    PXTrace.WriteInformation($"Running ReportCalculationEngine for {definitionLinks.Count} definition(s).");
+                    var engine = new ReportCalculationEngine(_graph);
+                    var enginePlaceholders = engine.CalculateAll(
+                        definitionLinks,
                         currYearData,
-                        prevYearData);
+                        prevYearData,
+                        cyOpeningData:    prevYearData,           // BalanceType=Beginning: EndingBalance of prior year-end → CY fiscal opening
+                        pyOpeningData:    prevYearPriorData,      // BalanceType=Beginning: EndingBalance of 2-years-ago year-end → PY fiscal opening
+                        cyJanOpeningData: januaryBeginningDataCY, // BalanceType=JanuaryBeginning: BeginningBalance of 01-{currYear}
+                        pyJanOpeningData: januaryBeginningDataPY, // BalanceType=JanuaryBeginning: BeginningBalance of 01-{prevYear}
+                        cyCumulativeData: cumulativeCYData,       // BalanceType=Debit/Credit/Movement: full-year Jan–Dec CY totals
+                        pyCumulativeData: cumulativePYData);      // BalanceType=Debit/Credit/Movement: full-year Jan–Dec PY totals
 
                     foreach (var kvp in enginePlaceholders)
                         finalPlaceholders[kvp.Key] = kvp.Value;

--- a/Financial_Report_Module_User_Manual_v2.md
+++ b/Financial_Report_Module_User_Manual_v2.md
@@ -1,0 +1,876 @@
+# Financial Report Module - User Manual v2
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Module Architecture](#2-module-architecture)
+3. [Screens Reference](#3-screens-reference)
+4. [Setting Up API Credentials](#4-setting-up-api-credentials)
+5. [Creating a Report Definition](#5-creating-a-report-definition)
+6. [Configuring Line Items](#6-configuring-line-items)
+7. [Line Types Explained](#7-line-types-explained)
+8. [Dimension Filters (Per-Line)](#8-dimension-filters-per-line)
+9. [Rounding & Formatting](#9-rounding--formatting)
+10. [Creating a Word Template](#10-creating-a-word-template)
+11. [Generating a Report](#11-generating-a-report)
+12. [Legacy Mode vs Definition Mode](#12-legacy-mode-vs-definition-mode)
+13. [Copy Definition](#13-copy-definition)
+14. [Reset Status](#14-reset-status)
+15. [Worked Examples](#15-worked-examples)
+16. [Troubleshooting](#16-troubleshooting)
+17. [Technical Reference](#17-technical-reference)
+
+---
+
+## 1. Overview
+
+The Financial Report Module is a customization for Acumatica ERP that automates the generation of financial statements (Balance Sheet, Profit & Loss, Cash Flow, Changes in Equity, and custom reports) by:
+
+1. Fetching GL data from a configurable Generic Inquiry (GI) via OData API
+2. Calculating line values using a configurable report definition
+3. Populating a Microsoft Word template with calculated values
+4. Saving the generated document back to Acumatica
+
+The module eliminates manual financial statement preparation and supports multi-company, multi-branch, and multi-period reporting.
+
+---
+
+## 2. Module Architecture
+
+```
++---------------------------+
+|  FR101000                 |   Main screen: select template, year, period,
+|  Financial Report         |   branch/org/ledger, link a definition,
+|  Generation               |   click Generate, Reset Status
++---------------------------+
+            |
+            v
++---------------------------+
+|  ReportGenerationService  |   Orchestrator: fetches data, runs engine,
+|  (Services/)              |   populates Word template, saves file
++---------------------------+
+     |              |
+     v              v
++-----------+  +-----------------------+
+| Financial |  | ReportCalculation     |
+| DataSvc   |  | Engine                |
+| (OData)   |  | (Definition-based)    |
++-----------+  +-----------------------+
+     |              |
+     v              v
++-----------+  +-----------------------+
+| GI via    |  | FLRTReportDefinition  |
+| OData API |  | FLRTReportLineItem    |
++-----------+  | (FR101002)            |
+               +-----------------------+
+```
+
+### Key Components
+
+| Component | Purpose |
+|---|---|
+| **FR101000** | Main report generation screen (select template, generate, download, reset status) |
+| **FR101002** | Report Definition maintenance (define line items, GI mapping, rounding, copy definitions) |
+| **ReportGenerationService** | Orchestrates the end-to-end report generation process |
+| **FinancialDataService** | Fetches GL data from the GI via OData API |
+| **ReportCalculationEngine** | Processes line items and produces placeholder values |
+| **WordTemplateService** | Extracts placeholders from and populates Word templates |
+| **GIColumnMapping** | Maps GI column names to expected data fields |
+| **RoundingSettings** | Carries rounding configuration to the engine |
+| **AuthService** | Handles OAuth2 authentication with the Acumatica API |
+| **CredentialProvider** | Retrieves and caches encrypted tenant credentials |
+| **TraceLogger** | Writes diagnostic information to the Acumatica Trace log |
+
+---
+
+## 3. Screens Reference
+
+### FR101000 - Financial Report Generation
+
+The main screen where you:
+- Upload a Word template (`.docx`)
+- Select the reporting year, month, branch, organization, and ledger
+- Optionally link a Report Definition
+- Click **Generate** to produce the report
+- Click **Download** to get the generated file
+- Click **Reset Status** to recover a stuck or failed report back to Pending
+
+### FR101002 - Report Definition
+
+The configuration screen where you define:
+- The GI data source and column mapping
+- Report line items (account ranges, subtotals, formulas)
+- Rounding and formatting settings
+- Use **Detect Columns** to auto-map GI columns
+- Use **Copy Definition** to duplicate an existing definition with all its line items
+
+---
+
+## 4. Setting Up API Credentials
+
+Before the module can fetch GL data, you need API credentials configured in the **Tenant Credentials** screen.
+
+### Required Fields
+
+| Field | Description | Example |
+|---|---|---|
+| **Company Number** | Unique integer linking reports to credentials | `1` |
+| **Tenant Name** | The Acumatica tenant/company name (must be unique) | `MyCompany` |
+| **Base URL** | The Acumatica instance URL (no trailing slash) | `https://mycompany.acumatica.com` |
+| **Client ID** | OAuth2 client ID (RSA encrypted at rest) | `xxxxxxxx-xxxx-xxxx-xxxx` |
+| **Client Secret** | OAuth2 client secret (RSA encrypted at rest) | `(your secret)` |
+| **Username** | API user account (RSA encrypted at rest) | `admin@MyCompany` |
+| **Password** | API user password (RSA encrypted at rest) | `(your password)` |
+
+### Important Notes
+- All sensitive fields (Username, Password, Client ID, Client Secret) are RSA-encrypted when saved
+- The API user must have permissions to access the Generic Inquiry via OData
+- The GI must be published and accessible via the OData endpoint
+- Use a dedicated API user (not a regular user account) for reliability
+- Company Number must be unique across all tenant records
+- Tenant Name must be unique across all tenant records
+
+---
+
+## 5. Creating a Report Definition
+
+Navigate to **FR101002 - Report Definition**.
+
+### Step 1: Create the Definition Header
+
+| Field | Description | Example |
+|---|---|---|
+| **Definition Code** | Unique identifier for this definition (immutable after save) | `BS_2024` |
+| **Report Type** | Type of financial statement | Balance Sheet, Profit & Loss, Cash Flow, Changes in Equity, Custom |
+| **Description** | Friendly description (up to 255 characters) | `Balance Sheet FY2024` |
+| **Active** | Whether this definition can be used | Checked |
+
+### Step 2: Configure the Data Source
+
+The **Data Source** section tells the module which GI to query and which columns to read.
+
+| Field | Default | Description |
+|---|---|---|
+| **Generic Inquiry Name** | `TrialBalance` | Name of the GI to query via OData (selectable from published GIs) |
+| **Account Column** | `Account` | Column containing the GL account code |
+| **Account Type Column** | `Type` | Column containing the account type (A/L/E/I/Q) |
+| **Beginning Balance Column** | `BeginningBalance` | Column for beginning balance |
+| **Ending Balance Column** | `EndingBalance` | Column for ending balance |
+| **Debit Column** | `Debit` | Column for debit amounts |
+| **Credit Column** | `Credit` | Column for credit amounts |
+
+#### Using Detect Columns
+
+1. Enter the **Generic Inquiry Name** (e.g. `TrialBalance`)
+2. Click the **Detect Columns** button in the toolbar
+3. The system connects to the API, fetches column metadata from the GI, and auto-maps column names using case-insensitive matching
+4. Review and adjust the mapped columns if needed
+5. Click **Save**
+
+The auto-mapping logic searches for columns by name:
+- Account: looks for "Account" (excluding "Sub" matches)
+- Type: looks for "Type" or "AccountType"
+- Beginning Balance: looks for "BeginningBalance", "Beginning", or "BegBal"
+- Ending Balance: looks for "EndingBalance", "Ending", or "YtdBalance"
+- Debit/Credit: looks for "Debit" and "Credit"
+
+> **Note:** The Detect Columns button is only enabled when a GI Name is entered. Tenant Credentials must be configured first.
+
+### Step 3: Configure Formatting
+
+| Field | Options | Description |
+|---|---|---|
+| **Rounding Level** | Units, Thousands, Millions | Scale factor for displayed values |
+| **Decimal Places** | 0, 1, 2 | Number of decimal places after rounding |
+
+**Examples:**
+- Units + 0 decimals: `1,808,344`
+- Thousands + 0 decimals: `1,808`
+- Thousands + 1 decimal: `1,808.3`
+- Millions + 2 decimals: `1.81`
+
+---
+
+## 6. Configuring Line Items
+
+Line items define what the report calculates. Each line produces two Word template placeholders: `{{LINECODE_CY}}` (current year) and `{{LINECODE_PY}}` (prior year).
+
+### Line Item Fields
+
+| Field | Description |
+|---|---|
+| **Sort Order** | Processing sequence (lower = first). Order matters because subtotals and formulas depend on earlier lines. |
+| **Line Code** | Unique identifier used in Word template placeholders (up to 100 characters). Use UPPER_CASE with underscores. |
+| **Description** | Human-readable description (up to 255 characters, for your reference only) |
+| **Line Type** | How this line's value is calculated (see Section 7) |
+| **Account From** | Start of GL account range (inclusive, up to 50 characters) |
+| **Account To** | End of GL account range (inclusive, up to 50 characters) |
+| **Account Type Filter** | Restrict to specific account type: Asset (A), Liability (L), Expense (E), Income (I), Equity (Q), or All |
+| **Balance Type** | Which balance to use: Ending, Beginning, Debit, Credit, Movement |
+| **Sign Rule** | As-Is or Flip Sign (multiply by -1) |
+| **Group / Parent Line** | Links this line to a Subtotal parent |
+| **Formula** | Mathematical expression for Calculated lines (up to 500 characters) |
+| **Visible in Report** | If unchecked, value is calculated but placeholder resolves to empty |
+| **Subaccount Filter** | Optional exact-match filter on subaccount code |
+| **Branch Filter** | Optional exact-match filter on branch (selectable from Acumatica branches) |
+| **Organization Filter** | Optional exact-match filter on organization (selectable from Acumatica organizations) |
+| **Ledger Filter** | Optional exact-match filter on ledger (selectable from Acumatica ledgers) |
+
+### Field Availability by Line Type
+
+| Field | Account Range | Subtotal | Calculated | Heading |
+|---|---|---|---|---|
+| Account From / To | Yes | - | - | - |
+| Account Type Filter | Yes | - | - | - |
+| Balance Type | Yes | - | - | - |
+| Sign Rule | Yes | - | - | - |
+| Parent Line Code | Yes | Yes | - | - |
+| Formula | - | - | Yes | - |
+| Visible | Yes | Yes | Yes | - |
+| Dimension Filters | Yes | - | - | - |
+
+When you change the Line Type, irrelevant fields are automatically cleared and disabled.
+
+### Validation Rules
+
+- **Line Code** is required and must be unique within the same definition
+- **Account From** and **Account To** are required for Account Range lines
+- **Formula** is required for Calculated lines
+- The system validates these rules on save and shows field-level error messages
+
+---
+
+## 7. Line Types Explained
+
+### Account Range
+
+Sums GL account balances within the specified `AccountFrom` to `AccountTo` range.
+
+**How it works:**
+1. Iterates all accounts returned by the GI
+2. Includes only accounts that fall within the `AccountFrom:AccountTo` range (smart alphanumeric comparison that handles segmented account codes like `1000-00`)
+3. Optionally filters by Account Type (Asset, Liability, etc.)
+4. Gets the specified balance type (Ending, Beginning, Debit, Credit, Movement)
+5. Applies automatic sign normalization (credit-normal accounts like Liability/Income/Equity are flipped to positive)
+6. Applies the Sign Rule if set to "Flip"
+7. Sums all matching values
+
+**Movement balance type:** When Balance Type is set to "Movement", the engine calculates `Debit - Credit` for each matching account, giving you the net activity for the period.
+
+**Example:**
+```
+Line Code:    CASH
+Account From: 10100
+Account To:   10199
+Balance Type: Ending Balance
+Sign Rule:    As-Is
+```
+This sums the ending balance of all accounts from 10100 to 10199.
+
+### Subtotal
+
+Sums all lines that have this line's code as their `Parent Line Code`.
+
+**How it works:**
+1. Finds all lines in the definition where `ParentLineCode = this LineCode`
+2. Sums their already-calculated values
+3. No account range or formula needed
+
+**Example:**
+```
+Sort Order  Line Code         Line Type      Parent Line
+10          CASH              Account Range  CURRENT_ASSETS
+20          RECEIVABLES       Account Range  CURRENT_ASSETS
+30          INVENTORY         Account Range  CURRENT_ASSETS
+40          CURRENT_ASSETS    Subtotal       (blank)
+```
+`CURRENT_ASSETS` = `CASH` + `RECEIVABLES` + `INVENTORY`
+
+> **Important:** Child lines (Sort Order 10-30) must be processed BEFORE the Subtotal line (Sort Order 40).
+
+### Calculated
+
+Evaluates a mathematical formula referencing other Line Codes.
+
+**Supported operators:** `+`, `-`, `*`, `/`, `(`, `)`
+
+**How it works:**
+1. Parses the Formula expression using a recursive descent parser
+2. Replaces each Line Code reference with its already-calculated value
+3. Evaluates the expression respecting operator precedence (`*` and `/` bind tighter than `+` and `-`)
+4. Supports parentheses for grouping
+5. Supports numeric literals (e.g. `* 100` for percentages)
+6. Supports unary minus (e.g. `-ADJUSTMENTS`)
+7. Division by zero is safely handled (returns 0)
+
+**Examples:**
+```
+Line Code: NET_INCOME
+Formula:   TOTAL_REVENUE - TOTAL_EXPENSES
+
+Line Code: WORKING_CAPITAL
+Formula:   CURRENT_ASSETS - CURRENT_LIABILITIES
+
+Line Code: GROSS_MARGIN_PCT
+Formula:   GROSS_PROFIT / TOTAL_REVENUE * 100
+```
+
+> **Important:** All referenced Line Codes must have a lower Sort Order (be calculated first). Unknown Line Codes default to 0 with a trace warning.
+
+### Heading
+
+Display-only line used for section headers in the Word template. No value is calculated. The placeholder resolves to an empty string. The `Visible` flag is automatically set to false for Heading lines.
+
+---
+
+## 8. Dimension Filters (Per-Line)
+
+Each Account Range line can optionally be restricted to specific dimensions. These filters appear in the line item fields.
+
+### Available Filters
+
+| Filter | Type | Description |
+|---|---|---|
+| **Subaccount Filter** | Free text (up to 30 chars) | Exact subaccount code (e.g. `000-000`) |
+| **Branch Filter** | Selector (from Acumatica branches) | Select from Acumatica branches |
+| **Organization Filter** | Selector (from Acumatica organizations) | Select from Acumatica organizations |
+| **Ledger Filter** | Selector (from Acumatica ledgers) | Select from Acumatica ledgers |
+
+### How Filters Work
+
+**No filters set (default):**
+- The engine uses the pre-aggregated data (all subaccounts, branches, and organizations summed per account)
+- This is the most common scenario and is the fastest path
+
+**Any filter set:**
+- The engine switches to the per-row detail data (one entry per GI row)
+- Each row is checked against all set filters (AND logic — all must match)
+- Only matching rows contribute to the line's total
+- When zero rows match, the trace log shows the filter values and sample data rows for debugging
+
+### Example Scenario
+
+Your company has 3 branches: HQ, WAREHOUSE, RETAIL. The report-level header has no branch filter (fetches all data). You want CASH to show only for HQ:
+
+```
+Line Code:     CASH
+Account From:  10100
+Account To:    10199
+Branch Filter: HQ          ← only HQ rows included
+```
+
+Lines without a Branch Filter will still include data from all 3 branches.
+
+### Important Notes
+
+- Filters are only applied to **Account Range** lines (not Subtotal, Calculated, or Heading)
+- All filters use **exact match** (case-insensitive)
+- Multiple filters are combined with AND logic
+- If the report header already filters to a specific branch, setting a different branch in the line filter will return 0 (that branch's data was never fetched)
+- The most useful scenario: leave report-level branch/org blank (fetch everything) and use per-line filters to scope individual lines
+
+---
+
+## 9. Rounding & Formatting
+
+### Rounding Levels
+
+| Level | Divisor | Raw Value | Result |
+|---|---|---|---|
+| **Units** | 1 | 1,808,344 | 1,808,344 |
+| **Thousands** | 1,000 | 1,808,344 | 1,808 |
+| **Millions** | 1,000,000 | 1,808,344 | 2 |
+
+Rounding uses `MidpointRounding.AwayFromZero` (standard banker's rounding away from zero).
+
+### Decimal Places
+
+| Decimal Places | Thousands Example |
+|---|---|
+| 0 | 1,808 |
+| 1 | 1,808.3 |
+| 2 | 1,808.34 |
+
+### Number Display Format (Definition Mode)
+
+| Value | Display |
+|---|---|
+| Positive | `1,234,567` |
+| Negative | `(1,234,567)` — accounting bracket notation |
+| Zero | `-` — dash (standard financial statement practice) |
+
+### Number Display Format (Legacy Mode)
+
+| Value | Display |
+|---|---|
+| All values | `#,##0` format (thousands separator, no decimals) |
+| Zero | `0` |
+| Negative | `-1,234,567` (minus sign) |
+
+---
+
+## 10. Creating a Word Template
+
+The Word template is a standard `.docx` file with placeholders that get replaced with calculated values.
+
+### File Naming Requirement
+
+The template filename **must** contain the text `FRTemplate` (case-sensitive) for the system to recognize it. Example: `BalanceSheet_FRTemplate_2024.docx`
+
+### Placeholder Format
+
+Placeholders use double curly braces: `{{PLACEHOLDER_NAME}}`
+
+### Definition-Mode Placeholders
+
+When a Report Definition is linked, placeholders use Line Codes:
+
+| Placeholder | Description |
+|---|---|
+| `{{CASH_CY}}` | Cash line, Current Year value |
+| `{{CASH_PY}}` | Cash line, Prior Year value |
+| `{{TOTAL_ASSETS_CY}}` | Total Assets, Current Year |
+| `{{NET_INCOME_PY}}` | Net Income, Prior Year |
+| `{{CY}}` | The current year number (e.g. `2024`) |
+| `{{PY}}` | The prior year number (e.g. `2023`) |
+
+### Legacy-Mode Placeholders
+
+When no Report Definition is linked, placeholders use raw account codes:
+
+| Placeholder | Description |
+|---|---|
+| `{{A10100_CY}}` | Account A10100, Current Year ending balance |
+| `{{A10100_PY}}` | Account A10100, Prior Year ending balance |
+| `{{A10100:A10199_e_CY}}` | Sum of accounts A10100 through A10199, ending balance, CY |
+| `{{A1???:A2???_e_CY}}` | Wildcard range: sum all accounts from A1000-A2999, ending balance, CY |
+| `{{Sum1_A_CY}}` | Sum all accounts starting with "A", CY |
+| `{{DebitSum3_B53_CY}}` | Sum debits for accounts starting with "B53", CY |
+| `{{CreditSum3_B53_CY}}` | Sum credits for accounts starting with "B53", CY |
+| `{{BegSum3_A11_CY}}` | Sum beginning balances for accounts starting with "A11", CY |
+| `{{A12345_sb000123_br001_CY}}` | Account with subaccount and branch dimensional filters |
+| `{{A12345_btcredit_CY}}` | Account with specific balance type (credit) |
+| `{{A12345_Jan1_CY}}` | January 1 beginning balance |
+| `{{A12345_debit_CY}}` | Cumulative debit activity |
+| `{{A12345_credit_CY}}` | Cumulative credit activity |
+
+### Placeholder Limit
+
+Templates are limited to a maximum of **1,000 placeholders** to prevent performance issues. If your template exceeds this limit, split it into multiple reports.
+
+### Template Design Tips
+
+1. Create the template in Microsoft Word with normal formatting
+2. Type placeholders directly — do NOT copy/paste from other sources (formatting characters can break matching)
+3. Use uppercase for Line Codes to match exactly
+4. Test with a small template first before building the full report
+5. Placeholders can appear in tables, headers, footers, and body text
+6. Do not split a placeholder across multiple lines in Word
+7. Avoid applying mixed formatting (bold/italic) within a single placeholder
+
+### Example Template Structure
+
+```
+                    BALANCE SHEET
+                As at December 31, {{CY}}
+                                        {{CY}}          {{PY}}
+
+ASSETS
+Current Assets
+  Cash and Cash Equivalents         {{CASH_CY}}     {{CASH_PY}}
+  Accounts Receivable               {{AR_CY}}       {{AR_PY}}
+  Inventory                         {{INV_CY}}      {{INV_PY}}
+Total Current Assets                {{CURR_ASSETS_CY}} {{CURR_ASSETS_PY}}
+
+Non-Current Assets
+  Property, Plant & Equipment       {{PPE_CY}}      {{PPE_PY}}
+Total Non-Current Assets            {{NONCURR_ASSETS_CY}} {{NONCURR_ASSETS_PY}}
+
+TOTAL ASSETS                        {{TOTAL_ASSETS_CY}} {{TOTAL_ASSETS_PY}}
+```
+
+---
+
+## 11. Generating a Report
+
+### Step-by-Step
+
+1. Navigate to **FR101000 - Financial Report**
+2. Select or create a report record
+3. Upload a Word template (attach `.docx` file with `FRTemplate` in the filename)
+4. Fill in the header fields:
+
+   | Field | Description |
+   |---|---|
+   | **Template Name** | Display name for this report (up to 225 characters) |
+   | **Company Number** | Links to tenant credentials |
+   | **Current Year** | The reporting year (selectable from Acumatica financial years) |
+   | **Financial Month** | The period month, defaults to December |
+   | **Branch** | Optional: filter data to a specific branch |
+   | **Organization** | Optional: filter data to a specific organization |
+   | **Ledger** | Optional: filter to a specific ledger (e.g. `ACTUAL`) |
+   | **Report Definition** | Optional: link to a Report Definition for structured calculation |
+
+5. Click **Save**
+6. Check the **Select** checkbox for your report
+7. Click **Generate Report**
+8. Wait for the status to change to **Ready to Download**
+9. Click **Download Report** to get the generated `.docx` file
+
+### Timeout Protection
+
+Report generation has a built-in **15-minute timeout**. If the process exceeds this limit, it is automatically cancelled and the status is set to Failed. This prevents indefinitely stuck reports.
+
+### What Happens During Generation
+
+1. Template file is extracted and placeholders are identified and categorized into three types:
+   - **Wildcard range** placeholders (e.g. `A????:B????_e_CY`)
+   - **Exact range** placeholders (e.g. `A74101:A75101_e_CY`)
+   - **Regular** placeholders (e.g. `A74101_CY`)
+2. Six parallel API calls fetch GL data:
+   - Current year period data
+   - Prior year period data
+   - January beginning balance (current year)
+   - January beginning balance (prior year)
+   - Cumulative CY data (Jan to selected month)
+   - Cumulative PY data (Jan to Dec prior year)
+3. If a Report Definition is linked:
+   - The ReportCalculationEngine processes all line items in SortOrder
+   - Account Range lines sum GL data within their ranges with sign normalization
+   - Subtotal and Calculated lines derive values from other lines
+   - Rounding and formatting are applied
+   - Engine placeholders take priority over legacy placeholders
+4. Legacy placeholders (raw account codes) fill in anything not covered by the definition
+5. Year constants (`{{CY}}` and `{{PY}}`) are added
+6. All placeholders are replaced in the Word document (headers, footers, body)
+7. The generated file is saved to Acumatica
+8. Temporary files are cleaned up
+9. Credential cache is cleared
+
+---
+
+## 12. Legacy Mode vs Definition Mode
+
+### Legacy Mode (no Report Definition linked)
+
+- Placeholders use raw account codes: `{{A10100_CY}}`
+- Returns the ending balance of that exact account
+- No sign correction, no rounding, no subtotals
+- Simple and direct — one placeholder per account
+- Supports Sum, DebitSum, CreditSum, BegSum prefix placeholders
+- Supports exact and wildcard range placeholders
+- Supports dimensional filtering via placeholder syntax
+- Best for quick, simple reports
+
+### Definition Mode (Report Definition linked)
+
+- Placeholders use Line Codes: `{{CASH_CY}}`
+- Full calculation engine with account ranges, subtotals, formulas
+- Automatic sign normalization (credit-normal accounts flipped for presentation)
+- Configurable rounding (Units/Thousands/Millions) with decimal places
+- Per-line dimension filters (Subaccount, Branch, Organization, Ledger)
+- Accounting bracket notation for negatives, dash for zeros
+- Best for formal financial statements
+
+### Both Modes Together
+
+When a Report Definition is linked, **both systems run**. Definition-mode placeholders take priority. Legacy placeholders fill in anything not covered by the definition. This allows you to use a definition for the main financial statement lines while still referencing individual accounts for notes or schedules.
+
+---
+
+## 13. Copy Definition
+
+The **Copy Definition** action on the FR101002 screen duplicates an existing Report Definition along with all its line items.
+
+### How to Use
+
+1. Open the definition you want to copy in FR101002
+2. Click **Copy Definition** in the toolbar
+3. Confirm the dialog prompt
+4. A new definition is created with:
+   - Definition Code = original code + `_COPY`
+   - Description = original description + ` (Copy)`
+   - All header settings (GI name, column mapping, rounding) are copied
+   - All line items are duplicated with the same sort order, codes, formulas, and settings
+5. Rename the Definition Code and Description as needed
+6. Modify line items for your variant
+
+This is useful for creating variations of an existing report (e.g. a Balance Sheet with notes, or a branch-specific P&L based on a consolidated template).
+
+---
+
+## 14. Reset Status
+
+The **Reset Status** action on the FR101000 screen allows you to recover a report that is stuck in "In Progress" or "Failed" status.
+
+### How to Use
+
+1. Select the report record (check the Select checkbox)
+2. Click **Reset Status** in the toolbar
+3. Confirm the dialog prompt
+4. The report status is reset to "Pending" (File not Generated)
+5. The previously generated file reference is cleared
+6. You can now edit the report and regenerate
+
+### When to Use
+
+- A report has been stuck in "In Progress" for an extended period (e.g. after a server restart)
+- A report failed and you want to retry after fixing the underlying issue
+- You want to clear a completed report and start fresh
+
+> **Note:** While any report has status "In Progress", all Generate and Download buttons are disabled system-wide. Resetting the stuck report will re-enable these buttons for all reports.
+
+---
+
+## 15. Worked Examples
+
+### Example 1: Simple Balance Sheet
+
+**Report Definition:** `BS` (Balance Sheet)
+
+| Sort | Line Code | Type | Account From | Account To | Type Filter | Sign | Parent |
+|---|---|---|---|---|---|---|---|
+| 10 | CASH | Account Range | 10100 | 10199 | All | As-Is | CURR_ASSETS |
+| 20 | AR | Account Range | 11000 | 11999 | All | As-Is | CURR_ASSETS |
+| 30 | INVENTORY | Account Range | 12000 | 12999 | All | As-Is | CURR_ASSETS |
+| 40 | CURR_ASSETS | Subtotal | | | | | TOTAL_ASSETS |
+| 50 | PPE | Account Range | 15000 | 15999 | All | As-Is | NONCURR_ASSETS |
+| 60 | NONCURR_ASSETS | Subtotal | | | | | TOTAL_ASSETS |
+| 70 | TOTAL_ASSETS | Subtotal | | | | | |
+| 80 | AP | Account Range | 20000 | 20999 | All | As-Is | CURR_LIAB |
+| 90 | CURR_LIAB | Subtotal | | | | | TOTAL_LIAB |
+| 100 | LOANS | Account Range | 25000 | 25999 | All | As-Is | NONCURR_LIAB |
+| 110 | NONCURR_LIAB | Subtotal | | | | | TOTAL_LIAB |
+| 120 | TOTAL_LIAB | Subtotal | | | | | |
+| 130 | SHARE_CAPITAL | Account Range | 30000 | 30999 | All | As-Is | TOTAL_EQUITY |
+| 140 | RET_EARNINGS | Account Range | 32000 | 32999 | All | As-Is | TOTAL_EQUITY |
+| 150 | TOTAL_EQUITY | Subtotal | | | | | |
+| 160 | LIAB_EQUITY | Calculated | | | | | |
+
+**Line 160 Formula:** `TOTAL_LIAB + TOTAL_EQUITY`
+
+**Verification check:** `TOTAL_ASSETS` should equal `LIAB_EQUITY`
+
+### Example 2: Profit & Loss with Dimension Filters
+
+A multi-branch company wants the P&L to show revenue broken down by branch:
+
+| Sort | Line Code | Type | Account From | Account To | Branch Filter |
+|---|---|---|---|---|---|
+| 10 | REVENUE_HQ | Account Range | 40000 | 49999 | HQ |
+| 20 | REVENUE_RETAIL | Account Range | 40000 | 49999 | RETAIL |
+| 30 | REVENUE_WAREHOUSE | Account Range | 40000 | 49999 | WAREHOUSE |
+| 40 | TOTAL_REVENUE | Calculated | | | |
+
+**Line 40 Formula:** `REVENUE_HQ + REVENUE_RETAIL + REVENUE_WAREHOUSE`
+
+> **Note:** The report header must have Branch and Organization left **blank** so all branch data is fetched.
+
+### Example 3: Using Hidden Lines and Percentages
+
+Sometimes you need intermediate calculations that shouldn't appear in the report:
+
+| Sort | Line Code | Type | Formula | Visible |
+|---|---|---|---|---|
+| 10 | REVENUE | Account Range | | Yes |
+| 20 | COGS | Account Range | | Yes |
+| 25 | _GROSS_AMT | Calculated | REVENUE - COGS | **No** |
+| 30 | GROSS_MARGIN | Calculated | _GROSS_AMT / REVENUE * 100 | Yes |
+
+Line `_GROSS_AMT` is calculated and available for formulas, but its placeholder resolves to empty in the Word template. Only `GROSS_MARGIN` (the percentage) appears.
+
+### Example 4: Using Copy Definition for Variants
+
+1. Create a consolidated Balance Sheet definition `BS_CONSOL`
+2. Use **Copy Definition** to create `BS_CONSOL_COPY`
+3. Rename to `BS_HQ` and add Branch Filters to each Account Range line for the HQ branch
+4. Now you have both a consolidated and branch-specific version sharing the same structure
+
+---
+
+## 16. Troubleshooting
+
+### Common Issues
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Placeholder shows `{{CASH_CY}}` in output | Line Code doesn't match | Check Line Code matches exactly (case-insensitive) |
+| Value shows `0` or `-` unexpectedly | Account range doesn't match any accounts | Verify AccountFrom/AccountTo match your chart of accounts |
+| Subtotal shows `0` | Child lines missing ParentLineCode | Set the Parent Line Code on each child line |
+| Formula shows `0` | Referenced Line Code not yet calculated | Ensure referenced lines have a LOWER Sort Order |
+| Detect Columns fails | API credentials not configured | Set up Tenant Credentials first |
+| All values are `0` | API returns no data | Check GI name, period, and that the GI has data in Acumatica |
+| Negative where positive expected | Credit-normal account sign | The engine auto-flips L/I/Q accounts. Use Flip Sign for manual override. |
+| Per-line branch filter returns `0` | Report header scoped to different branch | Leave report header branch blank when using per-line filters |
+| Generate button disabled | Another report is In Progress | Wait for it to complete, or use Reset Status on the stuck report |
+| Report stuck In Progress | Server restart or timeout | Use **Reset Status** to recover the report to Pending |
+| "Template contains X placeholders" error | Too many placeholders | Maximum is 1,000. Simplify or split into multiple reports. |
+| "Report generation timed out" | Very large dataset or slow API | Check template complexity, try during off-hours |
+| Screen doesn't show new fields | Old ASPX cached | Recycle app pool or re-publish the customization |
+
+### Sign Normalization
+
+The engine automatically normalizes signs based on account type:
+
+| Account Type | GL Natural Sign | Engine Treatment |
+|---|---|---|
+| Asset (A) | Debit (positive) | Kept as-is |
+| Expense (E) | Debit (positive) | Kept as-is |
+| Liability (L) | Credit (negative in GL) | Flipped to positive |
+| Income (I) | Credit (negative in GL) | Flipped to positive |
+| Equity (Q) | Credit (negative in GL) | Flipped to positive |
+
+The **Sign Rule** on the line item is an additional override applied AFTER auto-normalization:
+- **As-Is**: No additional change
+- **Flip Sign**: Multiplies by -1 (use when you need to subtract in a subtotal context)
+
+### Checking Trace Logs
+
+The module writes detailed trace information during generation. Check the **Acumatica Trace** (System > Management > Trace) for:
+
+- `ReportCalculationEngine: Processing X line items for DefinitionID Y`
+- `[0010] CASH               CY=    50,000  PY=    45,000`
+- `Account range 10100:10199 matched 5 accounts → 50,000`
+- `Account range 10100:10199 [filtered] matched 2 detail rows → 25,000` (when filters are active)
+- Filter values and sample data rows when zero rows match (helps debug dimension filter issues)
+- Placeholder counts by type (regular, exact range, wildcard range)
+- Total generation time in milliseconds
+- Authentication and API call status
+
+---
+
+## 17. Technical Reference
+
+### Database Tables
+
+| Table | Purpose |
+|---|---|
+| `FLRTFinancialReport` | Main report records (template, year, period, branch, definition link, status, file IDs) |
+| `FLRTReportDefinition` | Report definition header (GI name, column mapping, rounding, report type) |
+| `FLRTReportLineItem` | Line items within a definition (account ranges, formulas, dimension filters, visibility) |
+| `FLRTTenantCredentials` | API credentials per tenant/company (RSA-encrypted sensitive fields) |
+
+### Screen IDs
+
+| Screen ID | Name | Purpose |
+|---|---|---|
+| FR101000 | Financial Report | Main generation screen (Generate, Download, Reset Status) |
+| FR101002 | Report Definition | Definition & line item configuration (Detect Columns, Copy Definition) |
+
+### Report Status Lifecycle
+
+| Status Constant | Display Name | Description |
+|---|---|---|
+| `File not Generated` | Pending | Initial state, report can be edited and generated |
+| `File Generation In Progress` | In Progress | Background generation running (all buttons disabled system-wide) |
+| `Ready to Download` | Ready to Download | Generation succeeded, file available for download |
+| `Failed to Generate File` | Failed | Error occurred during generation |
+
+### GI Column Name Derivation (OData)
+
+When the module fetches data from a GI via OData, column names are derived as:
+- If the GI column has a **Caption**: `Caption.Replace(" ", "")` (spaces stripped)
+- If no Caption but has a **Field**: `ObjectName_FieldName`
+- Formula columns without captions are skipped
+
+### Calculation Engine Processing Order
+
+1. Lines are loaded ordered by `SortOrder ASC`
+2. Heading lines are skipped (no calculation)
+3. Account Range lines are processed first (they read GL data)
+4. Subtotal lines sum their children (children must be processed earlier)
+5. Calculated lines evaluate their formula (referenced lines must be processed earlier)
+6. Values are stored for both CY and PY in separate dictionaries
+7. After all lines are processed, the placeholder map is built
+8. Non-visible lines and Heading lines get empty string placeholders
+9. Rounding is applied during placeholder formatting
+
+### Account Code Comparison
+
+The engine uses a smart alphanumeric comparison for account ranges:
+- Segmented codes (containing `-`) are compared segment by segment
+- Numeric segments are compared numerically (so `2` < `10`)
+- Non-segmented codes use character-by-character comparison with numeric grouping
+- Comparison is case-insensitive
+
+### Formula Syntax
+
+```
+OPERAND: LineCode | NumericLiteral
+OPERATOR: + | - | * | /
+EXPRESSION: OPERAND (OPERATOR OPERAND)*
+GROUPING: ( EXPRESSION )
+UNARY: -OPERAND
+
+Examples:
+  REVENUE - EXPENSES
+  (REVENUE - COGS) / REVENUE * 100
+  TOTAL_LIAB + TOTAL_EQUITY
+  GROSS_PROFIT - OPEX - FINANCE_COSTS
+  -ADJUSTMENTS + NET_INCOME
+```
+
+### API Data Flow
+
+```
+1. ReportGenerationService reads FLRTFinancialReport record
+2. If DefinitionID is set, loads FLRTReportDefinition
+3. Creates GIColumnMapping from definition (or uses defaults)
+4. Creates RoundingSettings from definition (or uses defaults: Units, 0 decimals)
+5. Creates FinancialDataService with the column mapping
+6. Six parallel API calls to the GI OData endpoint:
+   a. Current year data (selected period)
+   b. Prior year data (same month, prior year)
+   c. January beginning balance - prior year
+   d. January beginning balance - current year
+   e. Cumulative CY data (Jan to selected month)
+   f. Cumulative PY data (Jan to Dec prior year)
+7. Placeholders are categorized: wildcard range, exact range, regular
+8. If DefinitionID is set:
+   - ReportCalculationEngine processes all line items
+   - Engine placeholders (LINECODE_CY/PY) are added first (highest priority)
+9. Legacy placeholders fill remaining gaps:
+   - Regular placeholders processed
+   - Exact range placeholders processed
+   - Wildcard range placeholders processed
+10. Year constants (CY, PY) are added
+11. WordTemplateService populates the template
+12. Generated file saved to Acumatica
+13. Temporary files cleaned up, credential cache cleared
+```
+
+### Error Messages Reference
+
+| Message | Cause |
+|---|---|
+| `Please select a template to generate the report.` | No record selected via checkbox |
+| `The selected template does not have any attached files.` | No file attached or filename missing `FRTemplate` |
+| `A report generation process is already running for this template.` | Another report is In Progress |
+| `Failed to authenticate. Please check credentials.` | Invalid API credentials |
+| `Current Year is not specified for the selected report.` | Missing Current Year field |
+| `No generated file is available for download.` | Report not yet generated or generation failed |
+| `No API credentials found for company` | No tenant credentials for the Company Number |
+| `Tenant mapping not found.` | Company Number doesn't match any tenant |
+| `Template contains X placeholders. Maximum allowed is Y.` | Too many placeholders (limit: 1,000) |
+| `Report generation timed out after X minutes.` | Generation exceeded 15-minute timeout |
+| `Definition Code must be unique.` | Duplicate Definition Code on save |
+| `Line Code must be unique within the same definition.` | Duplicate Line Code in same definition |
+| `Account From is required for Account Range line types.` | Missing Account From on Account Range line |
+| `Formula is required for Calculated line types.` | Missing Formula on Calculated line |
+| `Generic Inquiry Name is required to detect columns.` | Detect Columns clicked without GI Name |
+| `No columns were detected from the specified Generic Inquiry.` | GI returned no data or doesn't exist |
+
+### Customization Package
+
+The module is deployed as an Acumatica Customization Package. To deploy to a new instance:
+
+1. Export the customization package from the source instance
+2. Import into the target instance via the Customization Projects screen
+3. Publish the customization
+4. Run any required SQL scripts to create/alter tables
+5. Configure API credentials for the new tenant
+6. Create or import Report Definitions
+
+---
+
+*Generated for FinancialReport Module v2.0 — March 2026*

--- a/Financial_Report_User_Guide_v2.md
+++ b/Financial_Report_User_Guide_v2.md
@@ -1,0 +1,1090 @@
+# FINANCIAL REPORT APPLICATION
+## Comprehensive User Guide v2
+
+---
+
+**Version:** 2.0
+**Last Updated:** March 2026
+**For:** Acumatica ERP Users
+
+---
+
+## Table of Contents
+
+1. [Introduction & Overview](#1-introduction--overview)
+2. [Getting Started](#2-getting-started)
+3. [Setting Up Tenant Credentials](#3-setting-up-tenant-credentials)
+4. [Creating a Report Definition](#4-creating-a-report-definition)
+5. [Configuring Line Items](#5-configuring-line-items)
+6. [The Calculation Engine](#6-the-calculation-engine)
+7. [Creating a Word Template](#7-creating-a-word-template)
+8. [Generating a Report](#8-generating-a-report)
+9. [Report Status & Workflow](#9-report-status--workflow)
+10. [Worked Examples](#10-worked-examples)
+11. [Troubleshooting Guide](#11-troubleshooting-guide)
+12. [Best Practices & Tips](#12-best-practices--tips)
+13. [Appendix A: Legacy Placeholder Reference](#13-appendix-a-legacy-placeholder-reference)
+14. [Appendix B: Error Message Reference](#14-appendix-b-error-message-reference)
+15. [Appendix C: Field Reference](#15-appendix-c-field-reference)
+16. [Appendix D: Glossary](#16-appendix-d-glossary)
+
+---
+
+## 1. Introduction & Overview
+
+### 1.1 What is the Financial Report Application?
+
+The Financial Report Application is an Acumatica ERP customization that automates the
+generation of financial statements — Balance Sheet, Profit & Loss, Cash Flow, Changes
+in Equity, and custom reports.
+
+The core workflow:
+
+1. You define a **Report Definition** that describes the structure of your financial
+   statement — which GL account ranges map to which report lines, how subtotals roll
+   up, and what formulas to apply.
+2. You create a **Word template** with placeholders like `{{CASH_CY}}` and
+   `{{TOTAL_ASSETS_PY}}`.
+3. The **ReportCalculationEngine** fetches GL data via OData, processes every line
+   item (account ranges, subtotals, formulas), applies sign normalization and
+   rounding, and populates the template.
+4. You download a finished `.docx` report.
+
+No code changes are needed when your chart of accounts evolves — just update the
+Report Definition.
+
+### 1.2 Key Capabilities
+
+| Capability | Description |
+|---|---|
+| **Report Definitions** | Configure account ranges, subtotals, calculated formulas, sign rules, and rounding — all without code |
+| **Calculation Engine** | Processes line items in sequence: Account Range → Subtotal → Calculated, with automatic sign normalization |
+| **Per-Line Dimension Filters** | Filter individual lines by Subaccount, Branch, Organization, or Ledger |
+| **Accounting Formatting** | Bracket notation for negatives `(1,234)`, dash for zeros `-`, configurable rounding (Units / Thousands / Millions) |
+| **Year-over-Year** | Every line produces both `{{CODE_CY}}` and `{{CODE_PY}}` automatically |
+| **Detect Columns** | Auto-map GI column names to definition fields with one click |
+| **Copy Definition** | Duplicate an existing definition with all line items to create variants |
+| **Parallel Data Fetching** | 6 concurrent API calls for CY, PY, beginning balances, and cumulative data |
+| **Timeout Protection** | 15-minute automatic timeout prevents stuck reports |
+| **Reset Status** | Recover stuck or failed reports back to Pending |
+| **Legacy Compatibility** | Raw account-code placeholders (`{{A10100_CY}}`) still work alongside definitions |
+
+### 1.3 Who Should Use This Guide?
+
+- **Finance Team Members** generating regular financial reports
+- **Accountants** preparing month-end and year-end statements
+- **Report Designers** creating definitions and Word templates
+- **Administrators** setting up credentials and the system
+
+### 1.4 Prerequisites
+
+- Acumatica ERP installed with the Financial Report customization published
+- API credentials configured (see Section 3)
+- Microsoft Word for template creation and report viewing
+- Basic understanding of your Chart of Accounts
+- Financial period data posted in General Ledger
+
+---
+
+## 2. Getting Started
+
+### 2.1 Screens
+
+| Screen | ID | Purpose |
+|---|---|---|
+| **Financial Report** | FR101000 | Create reports, upload templates, generate, download, reset status |
+| **Report Definition** | FR101002 | Define report structure, line items, GI mapping, rounding |
+| **Tenant Credentials** | — | Configure API credentials (admin only) |
+
+### 2.2 Recommended Workflow
+
+```
+Administrator: Configure Tenant Credentials (one-time)
+                          │
+                          ▼
+Report Designer: Create Report Definition in FR101002
+                 ├── Set GI name & column mapping
+                 ├── Add line items (Account Range, Subtotal, Calculated, Heading)
+                 ├── Configure rounding & formatting
+                 └── Save
+                          │
+                          ▼
+Report Designer: Create Word Template (.docx)
+                 ├── Use {{LINECODE_CY}} / {{LINECODE_PY}} placeholders
+                 ├── Include {{CY}} / {{PY}} for year labels
+                 └── Filename must contain "FRTemplate"
+                          │
+                          ▼
+Report User:     Create Report Record in FR101000
+                 ├── Set Company Number, Year, Month, Branch/Org/Ledger
+                 ├── Link the Report Definition
+                 ├── Upload the Word template
+                 └── Click Generate Report → Download Report
+```
+
+---
+
+## 3. Setting Up Tenant Credentials
+
+> This section is for **Administrators**. Regular users should have credentials configured before creating reports.
+
+### 3.1 What are Tenant Credentials?
+
+Authentication details for the Acumatica OData API. Each company/tenant needs its own record. All sensitive fields (Username, Password, Client ID, Client Secret) are RSA-encrypted at rest.
+
+### 3.2 Configuration
+
+1. Navigate to **Tenant Credentials Maintenance**
+2. Click **Add New**
+3. Fill in:
+
+| Field | Description | Example |
+|---|---|---|
+| **Company Number** | Unique integer (links reports to credentials) | `1` |
+| **Tenant Name** | Unique descriptive name | `MainCompany` |
+| **Base URL** | Acumatica instance URL, no trailing slash | `https://server/AcumaticaERP` |
+| **Username** | API user account (encrypted) | `apiuser@company.com` |
+| **Password** | API user password (encrypted) | ••••••• |
+| **Client ID** | OAuth2 Client ID (encrypted) | `abc123xyz` |
+| **Client Secret** | OAuth2 Client Secret (encrypted) | ••••••• |
+
+4. Click **Save**
+
+### 3.3 Important Notes
+
+- Company Number and Tenant Name must each be unique
+- The API user must have OData access to the Generic Inquiry used by your definitions
+- Use a dedicated service account, not a personal user
+- Rotate credentials periodically
+
+---
+
+## 4. Creating a Report Definition
+
+Report Definitions are the heart of the new engine. They describe the structure of your financial statement — which GL accounts feed into which report lines, how lines roll up into subtotals, and what formulas to apply.
+
+Navigate to **FR101002 - Report Definition**.
+
+### 4.1 Definition Header
+
+| Field | Description | Example |
+|---|---|---|
+| **Definition Code** | Unique identifier (immutable after first save) | `BS_2024` |
+| **Report Type** | Balance Sheet, Profit & Loss, Cash Flow, Changes in Equity, or Custom | `Balance Sheet` |
+| **Description** | Friendly description (up to 255 characters) | `Balance Sheet FY2024` |
+| **Active** | Whether this definition can be linked to reports | Checked |
+
+### 4.2 Data Source — GI & Column Mapping
+
+The definition tells the engine which Generic Inquiry to query and which columns contain the data.
+
+| Field | Default | Description |
+|---|---|---|
+| **Generic Inquiry Name** | `TrialBalance` | The GI to query via OData (selectable from published GIs) |
+| **Account Column** | `Account` | GL account code |
+| **Account Type Column** | `Type` | Account type: A (Asset), L (Liability), E (Expense), I (Income), Q (Equity) |
+| **Beginning Balance Column** | `BeginningBalance` | Beginning balance |
+| **Ending Balance Column** | `EndingBalance` | Ending balance |
+| **Debit Column** | `Debit` | Debit amounts |
+| **Credit Column** | `Credit` | Credit amounts |
+
+#### Detect Columns (Auto-Mapping)
+
+Instead of manually entering column names:
+
+1. Enter the **Generic Inquiry Name**
+2. Click **Detect Columns** in the toolbar
+3. The system connects to the API, reads column metadata, and auto-maps using case-insensitive name matching:
+   - "Account" → Account Column (excludes "Subaccount" matches)
+   - "Type" or "AccountType" → Type Column
+   - "BeginningBalance", "Beginning", or "BegBal" → Beginning Balance Column
+   - "EndingBalance", "Ending", or "YtdBalance" → Ending Balance Column
+   - "Debit" → Debit Column
+   - "Credit" → Credit Column
+4. Review and adjust if needed, then **Save**
+
+> Detect Columns requires Tenant Credentials to be configured. The button is only enabled when a GI Name is entered.
+
+### 4.3 Rounding & Formatting
+
+| Field | Options | Description |
+|---|---|---|
+| **Rounding Level** | Units, Thousands, Millions | Divides values by 1 / 1,000 / 1,000,000 |
+| **Decimal Places** | 0, 1, 2 | Decimal places after rounding |
+
+**Examples with raw value 1,808,344:**
+
+| Rounding | Decimals | Output |
+|---|---|---|
+| Units | 0 | `1,808,344` |
+| Thousands | 0 | `1,808` |
+| Thousands | 1 | `1,808.3` |
+| Millions | 2 | `1.81` |
+
+Rounding uses `MidpointRounding.AwayFromZero`.
+
+**Number display:**
+
+| Value | Display |
+|---|---|
+| Positive | `1,234,567` |
+| Negative | `(1,234,567)` — accounting bracket notation |
+| Zero | `-` — dash |
+
+### 4.4 Copy Definition
+
+To create a variant of an existing definition:
+
+1. Open the source definition in FR101002
+2. Click **Copy Definition** in the toolbar
+3. Confirm the dialog
+4. A new definition is created:
+   - Code = original + `_COPY`
+   - Description = original + ` (Copy)`
+   - All header settings (GI, columns, rounding) are copied
+   - All line items are duplicated with the same sort order, codes, formulas, filters
+5. Rename the code and description, then modify line items as needed
+
+---
+
+## 5. Configuring Line Items
+
+Line items are the rows of your report definition. Each line produces two Word template placeholders: `{{LINECODE_CY}}` (current year) and `{{LINECODE_PY}}` (prior year).
+
+### 5.1 Line Item Fields
+
+| Field | Description |
+|---|---|
+| **Sort Order** | Processing sequence (lower = first). Order matters — subtotals and formulas depend on earlier lines. |
+| **Line Code** | Unique identifier within the definition (up to 100 chars). Becomes the placeholder name. Use UPPER_CASE with underscores. |
+| **Description** | Human-readable label (up to 255 chars, for your reference) |
+| **Line Type** | How this line's value is calculated (see below) |
+| **Account From** | Start of GL account range, inclusive (Account Range only) |
+| **Account To** | End of GL account range, inclusive (Account Range only) |
+| **Account Type Filter** | Restrict to: Asset (A), Liability (L), Expense (E), Income (I), Equity (Q), or All |
+| **Balance Type** | Ending (default), Beginning, Debit, Credit, or Movement |
+| **Sign Rule** | As-Is (default) or Flip Sign (multiply by -1) |
+| **Group / Parent Line** | Links this line to a Subtotal parent |
+| **Formula** | Mathematical expression for Calculated lines (up to 500 chars) |
+| **Visible in Report** | If unchecked, value is calculated but placeholder resolves to empty |
+| **Subaccount Filter** | Optional exact-match filter (up to 30 chars) |
+| **Branch Filter** | Optional exact-match filter (selectable from Acumatica branches) |
+| **Organization Filter** | Optional exact-match filter (selectable from Acumatica organizations) |
+| **Ledger Filter** | Optional exact-match filter (selectable from Acumatica ledgers) |
+
+### 5.2 Line Types
+
+#### Account Range
+
+Sums GL account balances within `AccountFrom` to `AccountTo`.
+
+**Processing steps:**
+1. Iterates all accounts from the GI
+2. Includes accounts in the range (smart alphanumeric comparison that handles segmented codes like `1000-00`)
+3. Optionally filters by Account Type
+4. Reads the specified Balance Type (Ending, Beginning, Debit, Credit, or Movement where Movement = Debit − Credit)
+5. Applies **sign normalization** — credit-normal accounts (L/I/Q) are flipped to positive
+6. Applies the **Sign Rule** if set to Flip
+7. Sums all matching values
+
+**Example:**
+```
+Line Code:    CASH
+Account From: 10100
+Account To:   10199
+Balance Type: Ending Balance
+Sign Rule:    As-Is
+→ Sums the ending balance of all accounts from 10100 to 10199
+```
+
+#### Subtotal
+
+Sums all lines whose `Parent Line Code` equals this line's code.
+
+```
+Sort  Code              Type           Parent
+10    CASH              Account Range  CURRENT_ASSETS
+20    RECEIVABLES       Account Range  CURRENT_ASSETS
+30    INVENTORY         Account Range  CURRENT_ASSETS
+40    CURRENT_ASSETS    Subtotal       (blank)
+
+→ CURRENT_ASSETS = CASH + RECEIVABLES + INVENTORY
+```
+
+Child lines must have a lower Sort Order than the Subtotal line.
+
+#### Calculated
+
+Evaluates a mathematical formula referencing other Line Codes.
+
+**Supported:** `+`, `-`, `*`, `/`, parentheses `()`, numeric literals, unary minus
+
+**Operator precedence:** `*` and `/` bind tighter than `+` and `-`
+
+**Examples:**
+```
+NET_INCOME          = TOTAL_REVENUE - TOTAL_EXPENSES
+GROSS_MARGIN_PCT    = (REVENUE - COGS) / REVENUE * 100
+LIAB_EQUITY         = TOTAL_LIAB + TOTAL_EQUITY
+ADJUSTED            = -ADJUSTMENTS + NET_INCOME
+```
+
+All referenced Line Codes must have a lower Sort Order. Unknown references default to 0 (with a trace warning). Division by zero returns 0.
+
+#### Heading
+
+Display-only line for section headers. No value is calculated. The placeholder resolves to empty. The `Visible` flag is automatically set to false.
+
+### 5.3 Field Availability by Line Type
+
+When you change the Line Type, irrelevant fields are automatically cleared and disabled.
+
+| Field | Account Range | Subtotal | Calculated | Heading |
+|---|---|---|---|---|
+| Account From / To | ✓ | — | — | — |
+| Account Type Filter | ✓ | — | — | — |
+| Balance Type | ✓ | — | — | — |
+| Sign Rule | ✓ | — | — | — |
+| Parent Line Code | ✓ | ✓ | — | — |
+| Formula | — | — | ✓ | — |
+| Visible | ✓ | ✓ | ✓ | — |
+| Dimension Filters | ✓ | — | — | — |
+
+### 5.4 Validation Rules
+
+The system validates on save:
+- **Line Code** is required and must be unique within the definition
+- **Account From** and **Account To** are required for Account Range lines
+- **Formula** is required for Calculated lines
+- Field-level error messages are shown for each violation
+
+### 5.5 Per-Line Dimension Filters
+
+Account Range lines can be restricted to specific dimensions:
+
+| Filter | Type | Example |
+|---|---|---|
+| **Subaccount Filter** | Free text | `000-000` |
+| **Branch Filter** | Selector | `HQ` |
+| **Organization Filter** | Selector | `CORPORATE` |
+| **Ledger Filter** | Selector | `ACTUAL` |
+
+**How filters work:**
+
+- **No filters set (default):** The engine uses pre-aggregated data (fastest path)
+- **Any filter set:** The engine switches to per-row detail data and checks each row against all filters (AND logic, case-insensitive exact match)
+- When zero rows match, the trace log shows filter values and sample data rows for debugging
+
+**Important:** If the report header (FR101000) already filters to a specific branch, setting a *different* branch in a line filter will return 0 — that branch's data was never fetched. Best practice: leave report-level Branch/Organization blank when using per-line filters.
+
+---
+
+## 6. The Calculation Engine
+
+The **ReportCalculationEngine** is the core of Definition Mode. Understanding how it works helps you design correct definitions.
+
+### 6.1 Processing Pipeline
+
+```
+1. Load all line items for the definition, ordered by SortOrder ASC
+2. For each line (skipping Headings):
+   ┌─────────────────────────────────────────────────────────┐
+   │  ACCOUNT RANGE                                          │
+   │  ├── Iterate GI accounts in the From:To range           │
+   │  ├── Filter by Account Type (if set)                    │
+   │  ├── Filter by Dimension Filters (if any set)           │
+   │  ├── Read the specified Balance Type                     │
+   │  ├── Apply sign normalization (flip L/I/Q to positive)  │
+   │  ├── Apply Sign Rule (flip if set)                      │
+   │  └── Sum all matching values                            │
+   ├─────────────────────────────────────────────────────────┤
+   │  SUBTOTAL                                               │
+   │  └── Sum all lines whose ParentLineCode = this LineCode │
+   ├─────────────────────────────────────────────────────────┤
+   │  CALCULATED                                             │
+   │  └── Evaluate formula (recursive descent parser)        │
+   └─────────────────────────────────────────────────────────┘
+   Store CY and PY values separately
+3. Build placeholder map:
+   ├── Visible lines → formatted value (e.g. "1,234" or "(500)" or "-")
+   └── Hidden lines & Headings → empty string
+```
+
+### 6.2 Sign Normalization
+
+The engine automatically normalizes signs so that financial statements read naturally:
+
+| Account Type | GL Natural Sign | Engine Treatment |
+|---|---|---|
+| Asset (A) | Debit (positive) | Kept as-is |
+| Expense (E) | Debit (positive) | Kept as-is |
+| Liability (L) | Credit (negative in GL) | **Flipped to positive** |
+| Income (I) | Credit (negative in GL) | **Flipped to positive** |
+| Equity (Q) | Credit (negative in GL) | **Flipped to positive** |
+
+The **Sign Rule** on the line item is applied *after* normalization:
+- **As-Is:** No additional change
+- **Flip Sign:** Multiplies by -1 (use when you need a value to subtract in a subtotal, e.g. showing COGS as a deduction from Revenue)
+
+### 6.3 Balance Types
+
+| Balance Type | What It Returns |
+|---|---|
+| **Ending** (default) | Ending balance for the selected period |
+| **Beginning** | Beginning balance for the selected period |
+| **Debit** | Debit amount for the selected period |
+| **Credit** | Credit amount for the selected period |
+| **Movement** | Net activity: Debit minus Credit |
+
+### 6.4 Account Code Comparison
+
+The engine uses smart alphanumeric comparison for account ranges:
+- Segmented codes (containing `-`) are compared segment by segment
+- Numeric segments are compared numerically (`2` < `10`)
+- Non-segmented codes use character-by-character comparison with numeric grouping
+- Comparison is case-insensitive
+
+### 6.5 Formula Evaluation
+
+The formula parser uses recursive descent with proper operator precedence:
+
+```
+Precedence (highest to lowest):
+  1. Parentheses ()
+  2. Unary minus -
+  3. Multiplication *, Division /
+  4. Addition +, Subtraction -
+
+Operands:
+  - Line Code references (looked up from already-calculated values)
+  - Numeric literals (e.g. 100, 1.5)
+
+Safety:
+  - Unknown Line Codes → 0 (with trace warning)
+  - Division by zero → 0
+```
+
+### 6.6 Priority: Engine vs Legacy
+
+When a Report Definition is linked to a report, **both** the engine and legacy placeholder systems run. The engine's placeholders take priority. Legacy placeholders fill in anything not covered by the definition.
+
+This means you can use a definition for the main financial statement lines (`{{CASH_CY}}`, `{{TOTAL_ASSETS_CY}}`) while still referencing individual accounts for notes or schedules (`{{A10100_CY}}`).
+
+### 6.7 Trace Logging
+
+The engine writes detailed trace information during processing:
+
+```
+ReportCalculationEngine: Processing 15 line items for DefinitionID 42.
+  [0010] CASH                           CY=       50,000  PY=       45,000
+    Account range 10100:10199 matched 5 accounts → 50,000
+  [0020] RECEIVABLES                    CY=      120,000  PY=      110,000
+  [0030] INVENTORY                      CY=       80,000  PY=       75,000
+  [0040] CURRENT_ASSETS                 CY=      250,000  PY=      230,000
+  ...
+  [0160] LIAB_EQUITY                    CY=      500,000  PY=      480,000
+ReportCalculationEngine produced 32 placeholders.
+```
+
+When dimension filters match zero rows, the trace shows filter values and sample data for debugging.
+
+Check traces at **System > Management > Trace** in Acumatica.
+
+---
+
+## 7. Creating a Word Template
+
+The Word template is a standard `.docx` file with placeholders that the engine replaces with calculated values.
+
+### 7.1 File Naming
+
+The template filename **must** contain `FRTemplate` (case-sensitive).
+
+- ✓ `BalanceSheet_FRTemplate_2024.docx`
+- ✓ `PL_FRTemplate.docx`
+- ✗ `BalanceSheet_Template_2024.docx`
+
+### 7.2 Placeholder Format
+
+Placeholders use double curly braces: `{{PLACEHOLDER_NAME}}`
+
+### 7.3 Definition-Mode Placeholders
+
+When a Report Definition is linked, use Line Codes from your definition:
+
+| Placeholder | Description |
+|---|---|
+| `{{CASH_CY}}` | Cash line, Current Year |
+| `{{CASH_PY}}` | Cash line, Prior Year |
+| `{{TOTAL_ASSETS_CY}}` | Total Assets, Current Year |
+| `{{NET_INCOME_PY}}` | Net Income, Prior Year |
+| `{{CY}}` | Current year number (e.g. `2024`) |
+| `{{PY}}` | Prior year number (e.g. `2023`) |
+
+Every line in your definition automatically produces both `_CY` and `_PY` placeholders.
+
+### 7.4 Placeholder Rules
+
+- Always include year suffix: `_CY` or `_PY`
+- Matching is case-insensitive
+- Do not include spaces inside braces
+- Do not split a placeholder across multiple lines in Word
+- Type placeholders directly — do NOT copy/paste from other sources (hidden formatting characters can break matching)
+- Avoid mixed formatting (bold/italic) within a single placeholder
+- Maximum **1,000 placeholders** per template
+
+### 7.5 Example Template: Balance Sheet
+
+```
+                        ABC COMPANY
+                        BALANCE SHEET
+                    As at December 31, {{CY}}
+
+                                            {{CY}}              {{PY}}
+ASSETS
+Current Assets
+  Cash and Cash Equivalents             {{CASH_CY}}         {{CASH_PY}}
+  Accounts Receivable                   {{AR_CY}}           {{AR_PY}}
+  Inventory                             {{INV_CY}}          {{INV_PY}}
+Total Current Assets                    {{CURR_ASSETS_CY}}  {{CURR_ASSETS_PY}}
+
+Non-Current Assets
+  Property, Plant & Equipment           {{PPE_CY}}          {{PPE_PY}}
+  Accumulated Depreciation              {{ACCUM_DEPR_CY}}   {{ACCUM_DEPR_PY}}
+Total Non-Current Assets                {{NONCURR_ASSETS_CY}} {{NONCURR_ASSETS_PY}}
+
+TOTAL ASSETS                            {{TOTAL_ASSETS_CY}} {{TOTAL_ASSETS_PY}}
+
+LIABILITIES
+Current Liabilities
+  Accounts Payable                      {{AP_CY}}           {{AP_PY}}
+  Accrued Expenses                      {{ACCRUED_CY}}      {{ACCRUED_PY}}
+Total Current Liabilities               {{CURR_LIAB_CY}}    {{CURR_LIAB_PY}}
+
+Non-Current Liabilities
+  Long-Term Loans                       {{LOANS_CY}}        {{LOANS_PY}}
+Total Non-Current Liabilities           {{NONCURR_LIAB_CY}} {{NONCURR_LIAB_PY}}
+
+TOTAL LIABILITIES                       {{TOTAL_LIAB_CY}}   {{TOTAL_LIAB_PY}}
+
+EQUITY
+  Share Capital                         {{SHARE_CAP_CY}}    {{SHARE_CAP_PY}}
+  Retained Earnings                     {{RET_EARN_CY}}     {{RET_EARN_PY}}
+TOTAL EQUITY                            {{TOTAL_EQUITY_CY}} {{TOTAL_EQUITY_PY}}
+
+TOTAL LIABILITIES & EQUITY              {{LIAB_EQUITY_CY}}  {{LIAB_EQUITY_PY}}
+```
+
+### 7.6 Template Design Tips
+
+- Use Word tables for clean column alignment in comparative reports
+- Add currency symbols outside the placeholder: `${{CASH_CY}}`
+- Placeholders work in headers, footers, tables, and body text
+- Start with a small test template before building the full report
+- Use `{{CY}}` and `{{PY}}` in column headers for dynamic year labels
+
+---
+
+## 8. Generating a Report
+
+### 8.1 Step-by-Step
+
+1. Navigate to **FR101000 - Financial Report**
+2. Create a new report record (auto-saves on insert)
+3. Fill in the header:
+
+| Field | Required | Description |
+|---|---|---|
+| **Template Name** | Yes | Descriptive name (up to 225 chars) |
+| **Company Number** | Yes | Links to Tenant Credentials |
+| **Current Year** | Yes | Selectable from Acumatica financial years |
+| **Financial Month** | Yes | Dropdown 01-12, defaults to December |
+| **Branch** | No | Filter data to a specific branch |
+| **Organization** | No | Filter data to a specific organization |
+| **Ledger** | No | Filter to a specific ledger (e.g. `ACTUAL`) |
+| **Report Definition** | **Recommended** | Link to a Report Definition for structured calculation |
+
+4. Upload a Word template (filename must contain `FRTemplate`)
+5. Click **Save**
+6. Check the **Select** checkbox for your report
+7. Click **Generate Report**
+8. Wait for status to change to **Ready to Download** (typically 1-5 minutes)
+9. Click **Download Report**
+
+### 8.2 What Happens During Generation
+
+```
+Phase 1: Validation & Setup
+  ├── Verify record selection, template file, credentials
+  ├── Load Report Definition (if linked) → GI mapping, rounding settings
+  └── Authenticate with Acumatica API (OAuth2)
+
+Phase 2: Template Analysis
+  ├── Extract all placeholders from the Word template
+  └── Categorize: wildcard range, exact range, regular
+
+Phase 3: Data Fetching (6 parallel API calls)
+  ├── Current year period data
+  ├── Prior year period data
+  ├── January beginning balance (current year)
+  ├── January beginning balance (prior year)
+  ├── Cumulative CY data (Jan → selected month)
+  └── Cumulative PY data (Jan → Dec prior year)
+
+Phase 4: Calculation Engine (if definition linked)
+  ├── Process all line items in SortOrder
+  ├── Account Range → sum GL data with sign normalization
+  ├── Subtotal → sum child lines
+  ├── Calculated → evaluate formulas
+  └── Build placeholder map with formatted values
+
+Phase 5: Legacy Processing (fills gaps not covered by definition)
+  ├── Regular placeholders (e.g. {{A10100_CY}})
+  ├── Exact range placeholders (e.g. {{A10100:A10199_e_CY}})
+  └── Wildcard range placeholders (e.g. {{A????:B????_e_CY}})
+
+Phase 6: Template Population & Cleanup
+  ├── Replace all placeholders in headers, footers, body
+  ├── Add year constants ({{CY}}, {{PY}})
+  ├── Save generated file to Acumatica
+  ├── Delete temporary files
+  └── Clear credential cache
+```
+
+**Engine placeholders take priority** over legacy placeholders. If both produce a value for the same key, the engine wins.
+
+### 8.3 Timeout Protection
+
+Report generation has a built-in **15-minute timeout**. If exceeded, the process is automatically cancelled and the status is set to Failed.
+
+---
+
+## 9. Report Status & Workflow
+
+### 9.1 Status Values
+
+| Status | Display | Meaning |
+|---|---|---|
+| `File not Generated` | Pending | Initial state — can edit and generate |
+| `File Generation In Progress` | In Progress | Background generation running |
+| `Ready to Download` | Ready | Generation succeeded — download available |
+| `Failed to Generate File` | Failed | Error occurred |
+
+### 9.2 Status Lifecycle
+
+```
+         ┌──────────────┐
+         │   Pending     │◄──── Reset Status (from any state)
+         └──────┬───────┘
+                │ Generate Report
+                ▼
+         ┌──────────────┐
+         │  In Progress  │
+         └───┬──────┬───┘
+        Success    Error/Timeout
+             │        │
+             ▼        ▼
+      ┌──────────┐  ┌────────┐
+      │  Ready   │  │ Failed │
+      └──────────┘  └────────┘
+```
+
+### 9.3 System-Wide Generation Lock
+
+Only **one** report can generate at a time across the entire system. While any report is In Progress:
+- All Generate and Download buttons are disabled for all users
+- All report fields become read-only
+- Other users must wait for completion
+
+### 9.4 Reset Status
+
+Recovers a stuck or failed report:
+
+1. Select the report (checkbox)
+2. Click **Reset Status**
+3. Confirm the dialog
+4. Status resets to Pending, generated file reference is cleared
+5. All buttons are re-enabled system-wide
+
+Use this when:
+- A report has been stuck In Progress (e.g. after a server restart)
+- A report failed and you want to retry
+- You want to clear a completed report and regenerate
+
+### 9.5 Regenerating
+
+Clicking Generate Report on a previously completed report overwrites the previous file. Download first if you want to keep the old version. The system does not maintain version history.
+
+### 9.6 Expected Generation Times
+
+| Data Volume | Typical Time |
+|---|---|
+| Small (< 1,000 accounts) | 1-2 minutes |
+| Medium (1,000-5,000 accounts) | 2-4 minutes |
+| Large (5,000-10,000 accounts) | 4-8 minutes |
+| Very Large (> 10,000 accounts) | 8-15 minutes |
+
+---
+
+## 10. Worked Examples
+
+### 10.1 Balance Sheet Definition
+
+**Definition Code:** `BS` | **Report Type:** Balance Sheet | **Rounding:** Thousands, 0 decimals
+
+| Sort | Line Code | Type | Account From | Account To | Type Filter | Sign | Parent |
+|---|---|---|---|---|---|---|---|
+| 10 | CASH | Account Range | 10100 | 10199 | All | As-Is | CURR_ASSETS |
+| 20 | AR | Account Range | 11000 | 11999 | All | As-Is | CURR_ASSETS |
+| 30 | INVENTORY | Account Range | 12000 | 12999 | All | As-Is | CURR_ASSETS |
+| 40 | CURR_ASSETS | Subtotal | | | | | TOTAL_ASSETS |
+| 50 | PPE | Account Range | 15000 | 15999 | All | As-Is | NONCURR_ASSETS |
+| 60 | NONCURR_ASSETS | Subtotal | | | | | TOTAL_ASSETS |
+| 70 | TOTAL_ASSETS | Subtotal | | | | | |
+| 80 | AP | Account Range | 20000 | 20999 | All | As-Is | CURR_LIAB |
+| 90 | CURR_LIAB | Subtotal | | | | | TOTAL_LIAB |
+| 100 | LOANS | Account Range | 25000 | 25999 | All | As-Is | NONCURR_LIAB |
+| 110 | NONCURR_LIAB | Subtotal | | | | | TOTAL_LIAB |
+| 120 | TOTAL_LIAB | Subtotal | | | | | |
+| 130 | SHARE_CAPITAL | Account Range | 30000 | 30999 | All | As-Is | TOTAL_EQUITY |
+| 140 | RET_EARNINGS | Account Range | 32000 | 32999 | All | As-Is | TOTAL_EQUITY |
+| 150 | TOTAL_EQUITY | Subtotal | | | | | |
+| 160 | LIAB_EQUITY | Calculated | | | | | |
+
+**Line 160 Formula:** `TOTAL_LIAB + TOTAL_EQUITY`
+
+**Verification:** `TOTAL_ASSETS` should equal `LIAB_EQUITY`.
+
+### 10.2 P&L with Branch Dimension Filters
+
+A multi-branch company wants revenue broken down by branch.
+
+| Sort | Line Code | Type | Account From | Account To | Branch Filter | Parent |
+|---|---|---|---|---|---|---|
+| 10 | REV_HQ | Account Range | 40000 | 49999 | HQ | |
+| 20 | REV_RETAIL | Account Range | 40000 | 49999 | RETAIL | |
+| 30 | REV_WAREHOUSE | Account Range | 40000 | 49999 | WAREHOUSE | |
+| 40 | TOTAL_REVENUE | Calculated | | | | |
+| 50 | COGS | Account Range | 50000 | 59999 | | |
+| 60 | GROSS_PROFIT | Calculated | | | | |
+
+**Formulas:**
+- Line 40: `REV_HQ + REV_RETAIL + REV_WAREHOUSE`
+- Line 60: `TOTAL_REVENUE - COGS`
+
+> Leave the report header Branch and Organization **blank** so all branch data is fetched.
+
+### 10.3 Hidden Lines for Intermediate Calculations
+
+| Sort | Line Code | Type | Formula | Visible |
+|---|---|---|---|---|
+| 10 | REVENUE | Account Range | | Yes |
+| 20 | COGS | Account Range | | Yes |
+| 25 | _GROSS_AMT | Calculated | REVENUE - COGS | **No** |
+| 30 | GROSS_MARGIN_PCT | Calculated | _GROSS_AMT / REVENUE * 100 | Yes |
+
+`_GROSS_AMT` is calculated and available for formulas, but its placeholder resolves to empty in the Word template. Only `GROSS_MARGIN_PCT` appears.
+
+### 10.4 Using Copy Definition for Variants
+
+1. Create a consolidated Balance Sheet definition `BS_CONSOL`
+2. Click **Copy Definition** → creates `BS_CONSOL_COPY`
+3. Rename to `BS_HQ`
+4. Add Branch Filter = `HQ` to each Account Range line
+5. Now you have both consolidated and branch-specific versions sharing the same structure
+
+---
+
+## 11. Troubleshooting Guide
+
+### 11.1 Engine / Definition Issues
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Subtotal shows 0 | Child lines missing Parent Line Code | Set Parent Line Code on each child line |
+| Subtotal shows 0 | Children have higher Sort Order | Ensure children have LOWER Sort Order than the Subtotal |
+| Formula shows 0 | Referenced Line Code not yet calculated | Ensure referenced lines have a LOWER Sort Order |
+| Formula shows 0 | Typo in formula Line Code reference | Check trace log for "unknown LineCode" warnings |
+| Negative where positive expected | Credit-normal account not flipped | Engine auto-flips L/I/Q. Use Flip Sign for manual override. |
+| Positive where negative expected | Double-flip | Remove Flip Sign if the engine already normalizes the account type |
+| Account Range shows 0 | Account range doesn't match any accounts | Verify AccountFrom/AccountTo match your chart of accounts |
+| Account Range shows 0 | Account Type Filter too restrictive | Try "All Types" to see if data appears |
+| Per-line filter returns 0 | Report header scoped to different branch | Leave report header Branch/Org blank when using per-line filters |
+| Per-line filter returns 0 | Filter value doesn't match GI data exactly | Check trace log for sample data rows; verify exact values |
+| Values not rounded | Rounding set to Units | Change Rounding Level to Thousands or Millions in the definition |
+
+### 11.2 Template / Placeholder Issues
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Placeholder shows `{{CASH_CY}}` in output | Line Code doesn't match | Verify Line Code in definition matches placeholder exactly |
+| Placeholder not replaced | Hidden formatting in Word | Delete and retype the placeholder (don't copy/paste) |
+| Placeholder not replaced | Missing year suffix | Must include `_CY` or `_PY` |
+| All values are 0 | API returns no data | Check GI name, period, and that the GI has data |
+| "Template contains X placeholders" error | Too many placeholders | Maximum is 1,000. Simplify or split into multiple reports. |
+
+### 11.3 Generation Issues
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Generate button disabled | Another report In Progress | Wait for completion, or Reset Status on the stuck report |
+| Report stuck In Progress | Server restart or crash | Use **Reset Status** to recover |
+| "Report generation timed out" | Very large dataset or slow API | Simplify template, try off-hours |
+| "Failed to authenticate" | Invalid credentials | Verify all fields in Tenant Credentials |
+| "No API credentials found" | Wrong Company Number | Verify Company Number matches a tenant record |
+| Generation fails immediately | Template file missing | Upload file with `FRTemplate` in the name |
+
+### 11.4 Pre-Generation Checklist
+
+- ☐ Tenant Credentials configured for the Company Number
+- ☐ Report Definition is Active and has line items configured
+- ☐ Template Name filled in, Current Year and Financial Month set
+- ☐ Template file attached (filename contains `FRTemplate`)
+- ☐ Report Definition linked in the report record
+- ☐ No other report shows "In Progress" status
+- ☐ Record is saved and selected (checkbox checked)
+- ☐ Financial data posted for the selected period
+
+### 11.5 Using Trace Logs
+
+Check **System > Management > Trace** for:
+- `ReportCalculationEngine: Processing X line items for DefinitionID Y` — confirms engine ran
+- `[0010] CASH  CY=50,000  PY=45,000` — line-by-line values
+- `Account range 10100:10199 matched 5 accounts → 50,000` — account match counts
+- `Account range ... [filtered] matched 0 of 200 detail rows` — filter debugging with sample data
+- `Filters: Sub='...' Branch='...' Org='...' Ledger='...'` — filter values when zero matches
+- `Formula references unknown LineCode 'TYPO'` — formula reference errors
+- `📊 Extracted X total placeholders` — placeholder categorization counts
+- `Total report generation completed in X ms` — performance timing
+
+---
+
+## 12. Best Practices & Tips
+
+### 12.1 Definition Design
+
+- Use meaningful Line Codes: `CASH`, `TOTAL_ASSETS`, `NET_INCOME` — not `LINE1`, `LINE2`
+- Set Sort Order with gaps (10, 20, 30...) to allow inserting lines later
+- Always ensure dependencies have lower Sort Order than the lines that reference them
+- Use hidden lines (`Visible = false`) for intermediate calculations that shouldn't appear in the report
+- Use **Copy Definition** to create variants instead of rebuilding from scratch
+- Test with a small definition (3-5 lines) before building the full statement
+
+### 12.2 Template Design
+
+- Always include `FRTemplate` in the filename
+- Use descriptive Template Names: "Balance Sheet Q4 2024" not "Report1"
+- Type placeholders directly in Word
+- Use Word tables for clean column alignment
+- Add `$` or currency symbols outside the placeholder: `${{CASH_CY}}`
+- Use `{{CY}}` and `{{PY}}` in column headers for dynamic year labels
+- Start with a small test template before building the full report
+
+### 12.3 Dimension Filters
+
+- Leave report-level Branch/Organization blank when using per-line filters
+- Per-line filters use exact match — verify the exact values in your GI data
+- Check the trace log when filters return unexpected zeros
+
+### 12.4 Performance
+
+- Generate large reports during off-hours
+- Coordinate with team to avoid generation conflicts (system-wide lock)
+- Keep templates under 1,000 placeholders
+- Legacy wildcard placeholders are more expensive than definition-mode lines
+
+### 12.5 Workflow
+
+- Use **Reset Status** to recover stuck reports instead of waiting
+- Regenerating overwrites the previous file — download first if you want to keep it
+- For monthly close: generate preliminary reports before close, then final reports after
+- Use dedicated API user accounts and rotate credentials periodically
+
+---
+
+## 13. Appendix A: Legacy Placeholder Reference
+
+Legacy placeholders work when **no** Report Definition is linked, or alongside a definition (definition placeholders take priority). They use raw account codes instead of Line Codes and do not include sign normalization, rounding, or accounting formatting.
+
+### Year Constants
+```
+{{CY}}  - Current Year (e.g., 2024)
+{{PY}}  - Previous Year (e.g., 2023)
+```
+
+### Simple Account Balance
+```
+{{AccountNumber_CY}}  - Ending balance, current year
+{{AccountNumber_PY}}  - Ending balance, previous year
+```
+
+### Sum by Prefix
+```
+{{Sum[Level]_[Prefix]_CY}}        - Sum accounts by prefix (ending balance)
+{{DebitSum[Level]_[Prefix]_CY}}   - Sum debits by prefix
+{{CreditSum[Level]_[Prefix]_CY}}  - Sum credits by prefix
+{{BegSum[Level]_[Prefix]_CY}}     - Sum beginning balances by prefix
+```
+Level = number of prefix characters (1-6). Example: `{{Sum1_A_CY}}` sums all "A" accounts.
+
+### Specific Balance Types
+```
+{{Account_debit_CY}}    - Cumulative debit (Jan to selected month)
+{{Account_credit_CY}}   - Cumulative credit (Jan to selected month)
+{{Account_Jan1_CY}}     - January 1 beginning balance
+```
+
+### Exact Account Range
+```
+{{Start:End_e_CY}}  - Sum ending balances in range
+{{Start:End_b_CY}}  - Sum beginning balances
+{{Start:End_c_CY}}  - Sum credits
+{{Start:End_d_CY}}  - Sum debits
+```
+
+### Wildcard Range
+```
+{{A????:B????_e_CY}}  - ? matches any single character
+```
+Both patterns must be the same length.
+
+### Dimensional Filtering
+```
+{{Account_sb[Subacct]_CY}}        - Filter by subaccount
+{{Account_br[Branch]_CY}}         - Filter by branch
+{{Account_or[Org]_CY}}            - Filter by organization
+{{Account_ld[Ledger]_CY}}         - Filter by ledger
+{{Account_bt[BalType]_CY}}        - Specific balance type
+{{Account_sb[Sub]_br[Br]_CY}}     - Multiple dimensions combined
+```
+
+---
+
+## 14. Appendix B: Error Message Reference
+
+| Error Message | Cause | Solution |
+|---|---|---|
+| "Please select a template to generate the report." | No record selected | Check Select checkbox |
+| "The selected template does not have any attached files." | Missing template | Upload file with `FRTemplate` in name |
+| "A report generation process is already running for this template." | Another report generating | Wait or Reset Status |
+| "Failed to authenticate. Please check credentials." | Invalid credentials | Verify Tenant Credentials |
+| "Current Year is not specified for the selected report." | Missing field | Enter Current Year |
+| "No generated file is available for download." | Not generated | Generate first |
+| "No API credentials found for company" | Missing credentials | Configure Tenant Credentials |
+| "Tenant mapping not found." | Company Number mismatch | Verify Company Number |
+| "Template contains X placeholders. Maximum allowed is 1000." | Too many | Simplify or split |
+| "Report generation timed out after 15 minutes." | Timeout | Simplify template |
+| "The selected template file is empty or could not be retrieved." | Corrupted file | Re-upload |
+| "Definition Code must be unique." | Duplicate | Choose different code |
+| "Line Code must be unique within the same definition." | Duplicate | Use unique code |
+| "Account From is required for Account Range line types." | Missing field | Enter Account From |
+| "Account To is required for Account Range line types." | Missing field | Enter Account To |
+| "Formula is required for Calculated line types." | Missing field | Enter formula |
+| "Generic Inquiry Name is required to detect columns." | No GI name | Enter GI Name |
+| "No columns were detected from the specified Generic Inquiry." | GI empty/invalid | Verify GI name |
+| "Tenant Name must be unique." | Duplicate | Choose different name |
+| "Company Number is required." | Missing field | Enter Company Number |
+
+---
+
+## 15. Appendix C: Field Reference
+
+### FR101000 - Financial Report
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| Template Name | String(225) | Yes | Report template name |
+| Description | String(50) | No | Brief description |
+| Company Number | Integer | Yes | Links to Tenant Credentials |
+| Current Year | String(4) | Yes | Reporting year (selector from financial years) |
+| Financial Month | String(2) | Yes | Period month 01-12, default "12" |
+| Branch | String(10) | No | Branch filter (selector) |
+| Organization | String(50) | No | Organization filter (selector) |
+| Ledger | String(20) | No | Ledger filter (selector) |
+| Report Definition | Integer | No | Link to FR101002 definition (selector) |
+| Status | String(20) | Read-only | Current report status |
+| Select | Boolean | No | Selection checkbox |
+
+### FR101002 - Report Definition Header
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| Definition Code | String(50) | Yes | Unique identifier (immutable after save) |
+| Description | String(255) | No | Friendly description |
+| Report Type | String(10) | Yes | BS, PL, CF, EQ, or CU |
+| Active | Boolean | Yes | Default true |
+| GI Name | String(100) | Yes | Generic Inquiry name, default "TrialBalance" |
+| Account Column | String(100) | Yes | Default "Account" |
+| Type Column | String(100) | Yes | Default "Type" |
+| Beginning Bal Column | String(100) | Yes | Default "BeginningBalance" |
+| Ending Bal Column | String(100) | Yes | Default "EndingBalance" |
+| Debit Column | String(100) | Yes | Default "Debit" |
+| Credit Column | String(100) | Yes | Default "Credit" |
+| Rounding Level | String(10) | Yes | UNITS, THOUS, or MILL |
+| Decimal Places | Integer | Yes | 0, 1, or 2 |
+
+### FR101002 - Line Items
+
+| Field | Type | Description |
+|---|---|---|
+| Sort Order | Integer | Processing sequence (lower = first) |
+| Line Code | String(100) | Unique identifier → `{{CODE_CY}}` placeholder |
+| Description | String(255) | Human-readable label |
+| Line Type | String(20) | ACCOUNT, SUBTOTAL, CALCULATED, HEADING |
+| Account From | String(50) | Range start (Account Range only) |
+| Account To | String(50) | Range end (Account Range only) |
+| Account Type Filter | String(5) | A, L, E, I, Q, or blank for All |
+| Balance Type | String(10) | ENDING, BEGINNING, DEBIT, CREDIT, MOVEMENT |
+| Sign Rule | String(10) | ASIS or FLIP |
+| Parent Line Code | String(100) | Links to Subtotal parent |
+| Formula | String(500) | Expression for Calculated lines |
+| Visible in Report | Boolean | Default true |
+| Subaccount Filter | String(30) | Exact match filter |
+| Branch Filter | String(30) | Exact match filter (selector) |
+| Organization Filter | String(30) | Exact match filter (selector) |
+| Ledger Filter | String(20) | Exact match filter (selector) |
+
+### Tenant Credentials
+
+| Field | Type | Encrypted | Description |
+|---|---|---|---|
+| Company Number | Integer | No | Unique identifier |
+| Tenant Name | String(50) | No | Unique tenant name |
+| Base URL | String(255) | No | API base URL |
+| Username | String | RSA | API username |
+| Password | String | RSA | API password |
+| Client ID | String | RSA | OAuth Client ID |
+| Client Secret | String | RSA | OAuth Client Secret |
+
+---
+
+## 16. Appendix D: Glossary
+
+| Term | Definition |
+|---|---|
+| **Report Definition** | A configured structure in FR101002 that describes how a financial statement is calculated |
+| **Line Code** | Unique identifier for a report line; becomes `{{CODE_CY}}` / `{{CODE_PY}}` in templates |
+| **Sort Order** | Processing sequence for line items — lower numbers are processed first |
+| **Account Range** | Line type that sums GL accounts within a From:To range |
+| **Subtotal** | Line type that sums all child lines (those with matching Parent Line Code) |
+| **Calculated** | Line type that evaluates a formula referencing other Line Codes |
+| **Heading** | Display-only line type for section headers |
+| **Sign Normalization** | Automatic flipping of credit-normal accounts (L/I/Q) to positive values |
+| **Flip Sign** | Manual sign override that multiplies a value by -1 after normalization |
+| **Movement** | Balance type calculated as Debit minus Credit (net activity) |
+| **Rounding Level** | Scale factor: Units (÷1), Thousands (÷1,000), Millions (÷1,000,000) |
+| **Parent Line Code** | Links a line to a Subtotal parent for automatic summation |
+| **CY / PY** | Current Year / Previous Year |
+| **GI** | Generic Inquiry — Acumatica's configurable data query tool |
+| **OData** | Open Data Protocol — RESTful API used to fetch GI data |
+| **FRTemplate** | Required text in template filenames for the system to recognize them |
+| **Legacy Mode** | Report generation using raw account-code placeholders without a definition |
+| **Definition Mode** | Report generation using a structured Report Definition with the calculation engine |
+| **RSA Encryption** | Encryption method used for storing sensitive credential fields |
+| **Reset Status** | Action that recovers a stuck/failed report back to Pending |
+| **Copy Definition** | Action that duplicates a definition with all its line items |
+| **Detect Columns** | Action that auto-maps GI column names to definition fields |
+
+---
+
+*Financial Report Application User Guide v2.0 — March 2026*

--- a/Multi_Definition_Report_Plan.md
+++ b/Multi_Definition_Report_Plan.md
@@ -1,0 +1,458 @@
+# Multi-Definition Report Plan
+
+**Branch:** Enhancement
+**Date:** 2026-03-10
+**Goal:** Allow a single Financial Report to link multiple Report Definitions, resolve all placeholders (including cross-definition formulas) via topological sort, and generate one unified Word document.
+
+---
+
+## Overview
+
+### Current State
+```
+FLRTFinancialReport
+  └── DefinitionID (single FK → FLRTReportDefinition)
+        └── Line items processed in SortOrder
+              └── Produces LINECODE_CY / LINECODE_PY placeholders
+```
+
+### Target State
+```
+FLRTFinancialReport
+  └── FLRTReportDefinitionLink (child grid)
+        ├── Link → BS Definition (prefix: BS) → BS_LINECODE_CY / BS_LINECODE_PY
+        ├── Link → PL Definition (prefix: PL) → PL_LINECODE_CY / PL_LINECODE_PY
+        └── Link → CF Definition (prefix: CF) → CF_LINECODE_CY / CF_LINECODE_PY
+
+All line items across all definitions → topological sort → single global dictionary
+→ One Word template, one generation run, one output file
+```
+
+---
+
+## Step 1 — Add `Prefix` Field to `FLRTReportDefinition`
+
+**File:** `FinancialReport/DAC/FLRTReportDefinition.cs`
+
+Add a new field `DefinitionPrefix` — a short 2–10 character code that identifies this definition in cross-definition formula references and in Word placeholders.
+
+```csharp
+#region DefinitionPrefix
+[PXDBString(10, IsUnicode = true)]
+[PXUIField(DisplayName = "Prefix")]
+[PXDefault]
+public virtual string DefinitionPrefix { get; set; }
+public abstract class definitionPrefix : PX.Data.BQL.BqlString.Field<definitionPrefix> { }
+#endregion
+```
+
+**Rules:**
+- Alphanumeric only, no underscores (validated on save)
+- Must be unique across all definitions
+- Examples: `BS`, `PL`, `CF`, `EQ`, `NOTE1`
+
+**UI:** Add this field to `FLRTReportDefinitionMaint.cs` — place it prominently near `DefinitionCD`.
+
+---
+
+## Step 2 — New DAC: `FLRTReportDefinitionLink`
+
+**File:** `FinancialReport/DAC/FLRTReportDefinitionLink.cs` *(new file)*
+
+This is the child table that links multiple definitions to a single report. It replaces the single `DefinitionID` field on `FLRTFinancialReport`.
+
+```csharp
+[Serializable]
+[PXCacheName("FLRT Report Definition Link")]
+public class FLRTReportDefinitionLink : PXBqlTable, IBqlTable
+{
+    #region LinkID
+    [PXDBIdentity(IsKey = true)]
+    public virtual int? LinkID { get; set; }
+    public abstract class linkID : PX.Data.BQL.BqlInt.Field<linkID> { }
+    #endregion
+
+    #region ReportID
+    [PXDBInt]
+    [PXDBDefault(typeof(FLRTFinancialReport.reportID))]
+    [PXParent(typeof(SelectFrom<FLRTFinancialReport>
+        .Where<FLRTFinancialReport.reportID.IsEqual<reportID.FromCurrent>>))]
+    public virtual int? ReportID { get; set; }
+    public abstract class reportID : PX.Data.BQL.BqlInt.Field<reportID> { }
+    #endregion
+
+    #region DefinitionID
+    [PXDBInt]
+    [PXUIField(DisplayName = "Definition")]
+    [PXSelector(
+        typeof(Search<FLRTReportDefinition.definitionID>),
+        typeof(FLRTReportDefinition.definitionCD),
+        typeof(FLRTReportDefinition.definitionPrefix),
+        typeof(FLRTReportDefinition.description),
+        typeof(FLRTReportDefinition.reportType),
+        SubstituteKey = typeof(FLRTReportDefinition.definitionCD),
+        DescriptionField = typeof(FLRTReportDefinition.description))]
+    public virtual int? DefinitionID { get; set; }
+    public abstract class definitionID : PX.Data.BQL.BqlInt.Field<definitionID> { }
+    #endregion
+
+    #region DisplayOrder
+    // Controls display order in the grid only. Has NO effect on calculation order.
+    // Calculation order is determined entirely by topological sort of dependencies.
+    [PXDBInt]
+    [PXUIField(DisplayName = "Display Order")]
+    [PXDefault(0)]
+    public virtual int? DisplayOrder { get; set; }
+    public abstract class displayOrder : PX.Data.BQL.BqlInt.Field<displayOrder> { }
+    #endregion
+
+    // Standard audit fields (CreatedDateTime, LastModifiedDateTime, Tstamp, etc.)
+}
+```
+
+**Key point:** `DisplayOrder` is purely cosmetic — it determines how rows appear in the grid. The actual calculation order is resolved automatically by topological sort.
+
+---
+
+## Step 3 — Modify `FLRTFinancialReport`
+
+**File:** `FinancialReport/DAC/FLRTFinancialReport.cs`
+
+Keep the existing `DefinitionID` field but mark it obsolete for backward compatibility. The generation service will check for `FLRTReportDefinitionLink` rows first; if none exist, it falls back to the single `DefinitionID`.
+
+```csharp
+#region DefinitionID
+/// <summary>
+/// Legacy single-definition link. Superseded by FLRTReportDefinitionLink.
+/// Kept for backward compatibility. If FLRTReportDefinitionLink rows exist
+/// for this report, this field is ignored.
+/// </summary>
+[PXDBInt]
+[PXUIField(DisplayName = "Report Definition (Legacy)", Visible = false)]
+...
+#endregion
+```
+
+---
+
+## Step 4 — Modify `FLRTFinancialReportMaint`
+
+**File:** `FinancialReport/Graph/FLRTFinancialReportMaint.cs`
+
+Add a `PXSelectBase` view for the child `FLRTReportDefinitionLink` grid:
+
+```csharp
+public SelectFrom<FLRTReportDefinitionLink>
+    .Where<FLRTReportDefinitionLink.reportID
+        .IsEqual<FLRTFinancialReport.reportID.FromCurrent>>
+    .OrderBy<FLRTReportDefinitionLink.displayOrder.Asc>
+    .View DefinitionLinks;
+```
+
+**UI changes:**
+- Add a `PXGrid` tab "Definitions" showing: Definition selector, Prefix (read-only from definition), Display Order
+- Hide the legacy `DefinitionID` field (or remove from layout)
+- The prefix column in the grid is read-only — it comes from the selected definition's `DefinitionPrefix`
+
+---
+
+## Step 5 — Overhaul `ReportCalculationEngine`
+
+**File:** `FinancialReport/Services/ReportCalculationEngine.cs`
+
+This is the core change. The engine needs three new capabilities:
+1. Accept multiple definitions + their prefixes
+2. Resolve formula tokens to global `PREFIX_LINECODE` keys (explicit and implicit)
+3. Topological sort to determine calculation order with cycle detection
+
+### 5.1 — New Entry Point
+
+Replace the current `Calculate(int definitionID, ...)` with:
+
+```csharp
+/// <summary>
+/// Multi-definition entry point.
+/// Loads all line items from all linked definitions, resolves cross-definition
+/// formula references, sorts by dependency order (topological sort), and
+/// calculates all values into a single unified placeholder dictionary.
+/// </summary>
+public Dictionary<string, string> CalculateAll(
+    IEnumerable<DefinitionLink> definitionLinks,  // each has DefinitionID + Prefix
+    FinancialApiData cyData,
+    FinancialApiData pyData)
+```
+
+Where `DefinitionLink` is a simple struct:
+```csharp
+public struct DefinitionLink
+{
+    public int DefinitionID;
+    public string Prefix;         // e.g. "BS", "PL", "CF"
+    public RoundingSettings Rounding;
+}
+```
+
+### 5.2 — Global Dictionary Structure
+
+Replace the two per-definition dictionaries with global ones keyed by `PREFIX_LINECODE`:
+
+```csharp
+// Before (single-definition):
+Dictionary<string, decimal> _cyValues  // key = "TOTAL_ASSETS"
+Dictionary<string, decimal> _pyValues  // key = "TOTAL_ASSETS"
+
+// After (multi-definition):
+Dictionary<string, decimal> _cyValues  // key = "BS_TOTAL_ASSETS"
+Dictionary<string, decimal> _pyValues  // key = "BS_TOTAL_ASSETS"
+```
+
+Every line item, regardless of which definition it belongs to, is stored in the global dictionary with its prefixed key.
+
+### 5.3 — Formula Token Resolution
+
+When evaluating a formula token, the engine resolves it as follows:
+
+```
+Given: current definition prefix = "CF"
+Known prefixes across all linked definitions = { "BS", "PL", "CF" }
+
+Token "DISPOSED_ASSETS"
+  → Does not start with any known prefix + "_"
+  → Implicit: own-definition reference
+  → Resolved key = "CF_DISPOSED_ASSETS"
+
+Token "BS_RETAINED_ASSETS"
+  → Starts with "BS_" and "BS" is a known prefix
+  → Explicit: cross-definition reference
+  → Resolved key = "BS_RETAINED_ASSETS"
+
+Token "REVENUE"
+  → Does not start with any known prefix + "_"
+  → Implicit: own-definition reference
+  → Resolved key = "CF_REVENUE"
+```
+
+**Prefix detection logic:**
+```
+For each known prefix P:
+    if token.StartsWith(P + "_", OrdinalIgnoreCase):
+        → cross-definition reference, resolved key = token (uppercased)
+        break
+If no prefix matched:
+    → own-definition reference, resolved key = currentPrefix + "_" + token
+```
+
+### 5.4 — Topological Sort (Kahn's Algorithm)
+
+```
+STEP 1: Load all line items from all definitions
+        Build node list: each node = (PREFIX_LINECODE, lineItem, definitionPrefix)
+
+STEP 2: Build dependency edges
+        For ACCOUNT lines    → no dependencies
+        For SUBTOTAL lines   → depends on all child lines (same definition, where
+                               childLine.ParentLineCode = this.LineCode)
+                               → edges: PREFIX_CHILDLINECODE → PREFIX_THIS
+        For CALCULATED lines → parse formula, resolve each token to PREFIX_LINECODE
+                               → edges: RESOLVED_TOKEN → PREFIX_THIS
+
+STEP 3: Kahn's algorithm
+        - Compute in-degree for each node
+        - Initialize queue with all zero-in-degree nodes
+        - While queue not empty:
+            - Dequeue node N
+            - Add N to sorted processing order
+            - For each node M that depends on N:
+                - Decrement M's in-degree
+                - If M's in-degree == 0: enqueue M
+
+STEP 4: Cycle detection
+        If sorted order count < total nodes:
+            → Remaining nodes form a cycle
+            → Identify and report: "Circular dependency: BS_EQUITY → PL_NET_INCOME → BS_EQUITY"
+            → Throw PXException with clear message
+
+STEP 5: Process nodes in sorted order
+        For each node in sorted order:
+            - Calculate CY and PY values
+            - Store in global _cyValues[PREFIX_LINECODE] and _pyValues[PREFIX_LINECODE]
+```
+
+### 5.5 — Updated `CalculateSubtotal`
+
+Currently queries all line items where `parentLineCode = subtotalLineCode` without definitionID filter. With multi-definition, scope this to within the same definition:
+
+```csharp
+// Query child lines within the same definition only
+WHERE parentLineCode = subtotalLineCode AND definitionID = currentDefinitionID
+```
+
+Then look up child values using prefixed keys: `_cyValues[prefix + "_" + child.LineCode]`
+
+### 5.6 — Updated `BuildPlaceholderMap`
+
+Keys are now prefixed:
+
+```csharp
+// Before:
+string cyKey = $"{line.LineCode}_{CY}";          // "TOTAL_ASSETS_CY"
+
+// After:
+string cyKey = $"{prefix}_{line.LineCode}_{CY}"; // "BS_TOTAL_ASSETS_CY"
+```
+
+This directly maps to `{{BS_TOTAL_ASSETS_CY}}` in the Word template.
+
+### 5.7 — Backward Compatibility
+
+Keep the existing `Calculate(int definitionID, ...)` method working. Internally it calls the new `CalculateAll` with a single-item definition list. The output placeholder keys will now be `PREFIX_LINECODE_CY` instead of `LINECODE_CY`.
+
+> **Migration note:** Existing Word templates using `{{TOTAL_ASSETS_CY}}` (no prefix) will break. Templates must be updated to use `{{BS_TOTAL_ASSETS_CY}}` after the definition prefix is assigned. This is a one-time migration.
+
+---
+
+## Step 6 — Modify `ReportGenerationService`
+
+**File:** `FinancialReport/Services/ReportGenerationService.cs`
+
+### 6.1 — Load Linked Definitions
+
+```csharp
+// Load all linked definitions for this report
+var links = SelectFrom<FLRTReportDefinitionLink>
+    .InnerJoin<FLRTReportDefinition>
+        .On<FLRTReportDefinition.definitionID.IsEqual<FLRTReportDefinitionLink.definitionID>>
+    .Where<FLRTReportDefinitionLink.reportID.IsEqual<@P.AsInt>>
+    .OrderBy<FLRTReportDefinitionLink.displayOrder.Asc>
+    .View.Select(_graph, report.ReportID);
+
+// Fall back to legacy single DefinitionID if no links found
+if (!links.Any() && report.DefinitionID != null)
+{
+    var def = ... // load single definition
+    links = new[] { (def, singleLink) };
+}
+```
+
+### 6.2 — GL Data Fetching (No Change)
+
+GL data is already fetched once and shared. This remains the same — all definitions share the same 6 API calls. Each definition's GI name could differ, so fetch per distinct GI name if definitions use different GIs.
+
+> **Consideration:** If BS uses `TrialBalance` GI and CF uses a different GI, the fetch needs to be per-GI-name, then the correct data set is passed to each definition's line items. The `DefinitionLink` struct carries the `GIColumnMapping` per definition.
+
+### 6.3 — Run Unified Calculation Engine
+
+```csharp
+var definitionLinkArgs = links.Select(l => new DefinitionLink
+{
+    DefinitionID = l.DefinitionID,
+    Prefix       = l.Definition.DefinitionPrefix,
+    Rounding     = RoundingSettings.From(l.Definition)
+}).ToList();
+
+var engine = new ReportCalculationEngine(_graph);
+var definitionPlaceholders = engine.CalculateAll(definitionLinkArgs, cyData, pyData);
+
+// Merge into the master placeholder dictionary
+// Definition values take priority over raw account placeholders
+foreach (var kvp in definitionPlaceholders)
+    masterPlaceholders[kvp.Key] = kvp.Value;
+```
+
+---
+
+## Step 7 — Validation on Save
+
+**File:** `FLRTReportDefinitionMaint.cs` and `FLRTFinancialReportMaint.cs`
+
+### On Definition Save
+- `DefinitionPrefix` must not be empty
+- `DefinitionPrefix` must be alphanumeric only (no underscores, no spaces)
+- `DefinitionPrefix` must be unique across all definitions (warn if duplicate exists)
+
+### On Report Save / Before Generation
+- Check that no two linked definitions share the same prefix
+- Check that no LineCode in any linked definition starts with another linked definition's `Prefix + "_"` (would cause ambiguity in implicit token resolution)
+- Surface clear validation errors before generation starts
+
+---
+
+## Step 8 — Circular Dependency Error Reporting
+
+When a cycle is detected during topological sort, the error message must be actionable:
+
+```
+Circular dependency detected in report definitions.
+The following line codes form a cycle:
+
+  BS_EQUITY (BalanceSheet)
+    → required by: PL_NET_INCOME (ProfitLoss)  [formula: REVENUE - BS_EQUITY]
+    → required by: BS_EQUITY (BalanceSheet)     [formula: PL_NET_INCOME + RESERVES]
+
+Please revise the formula in BS_EQUITY or PL_NET_INCOME to break the cycle.
+```
+
+---
+
+## Data Flow After Changes
+
+```
+FLRTFinancialReportMaint (UI)
+  → User selects report, clicks Generate
+      ↓
+ReportGenerationService.Execute()
+  ├─ Load FLRTReportDefinitionLink rows for this report
+  ├─ Extract Word template → get all {{...}} placeholders
+  ├─ Fetch GL data (6 parallel API calls, shared across all definitions)
+  ├─ Process raw account placeholders ({{A10100_CY}}, ranges, etc.) — unchanged
+  ├─ ReportCalculationEngine.CalculateAll(definitionLinks, cyData, pyData)
+  │     ├─ Load ALL line items from ALL definitions
+  │     ├─ Build dependency graph (ACCOUNT→SUBTOTAL→CALCULATED + cross-def)
+  │     ├─ Topological sort (Kahn's algorithm)
+  │     ├─ Detect cycles → error if found
+  │     ├─ Process in resolved order → global _cyValues / _pyValues
+  │     └─ BuildPlaceholderMap → { "BS_TOTAL_ASSETS_CY": "1,250,000", ... }
+  ├─ Merge all placeholder sources
+  │     Priority: definition engine values > raw account placeholders
+  └─ WordTemplateService.PopulateTemplate()
+        → replaces {{BS_TOTAL_ASSETS_CY}}, {{PL_NET_INCOME_PY}}, etc.
+        → one output Word document
+```
+
+---
+
+## Word Template Placeholder Format (Summary)
+
+| Source | Old Format | New Format |
+|---|---|---|
+| Definition line item | `{{TOTAL_ASSETS_CY}}` | `{{BS_TOTAL_ASSETS_CY}}` |
+| Definition line item (PY) | `{{TOTAL_ASSETS_PY}}` | `{{BS_TOTAL_ASSETS_PY}}` |
+| Raw account code | `{{A10100_CY}}` | `{{A10100_CY}}` (unchanged) |
+| Account range | `{{A10100:A19999_e_CY}}` | `{{A10100:A19999_e_CY}}` (unchanged) |
+| Cross-def in formula | N/A | `BS_RETAINED_ASSETS` in CF formula |
+
+---
+
+## Files to Create / Modify
+
+| File | Action |
+|---|---|
+| `DAC/FLRTReportDefinitionLink.cs` | **Create** — new link DAC |
+| `DAC/FLRTReportDefinition.cs` | **Modify** — add `DefinitionPrefix` field |
+| `DAC/FLRTFinancialReport.cs` | **Modify** — mark `DefinitionID` as legacy |
+| `Graph/FLRTFinancialReportMaint.cs` | **Modify** — add `DefinitionLinks` view + grid |
+| `Graph/FLRTReportDefinitionMaint.cs` | **Modify** — add `DefinitionPrefix` to UI |
+| `Services/ReportCalculationEngine.cs` | **Modify** — topological sort, global dict, cross-def resolution |
+| `Services/ReportGenerationService.cs` | **Modify** — load links, call `CalculateAll` |
+
+---
+
+## Implementation Order
+
+1. `FLRTReportDefinition.cs` — add Prefix field (small, no dependencies)
+2. `FLRTReportDefinitionLink.cs` — create new DAC
+3. `FLRTFinancialReportMaint.cs` — add grid (UI wiring)
+4. `FLRTReportDefinitionMaint.cs` — add Prefix to UI + validation
+5. `ReportCalculationEngine.cs` — core overhaul (topological sort + cross-def)
+6. `ReportGenerationService.cs` — wire up multi-definition flow
+7. End-to-end test with a two-definition report (BS + CF with cross-formula)

--- a/SQL/01_AddDefinitionPrefix.sql
+++ b/SQL/01_AddDefinitionPrefix.sql
@@ -1,0 +1,61 @@
+-- ============================================================
+-- Script 01: Add DefinitionPrefix column to FLRTReportDefinition
+-- Run this FIRST before any other migration scripts.
+-- ============================================================
+
+-- Add the DefinitionPrefix column (nullable initially to allow migration)
+IF NOT EXISTS (
+    SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'FLRTReportDefinition'
+      AND COLUMN_NAME = 'DefinitionPrefix'
+)
+BEGIN
+    ALTER TABLE FLRTReportDefinition
+    ADD DefinitionPrefix NVARCHAR(10) NULL;
+
+    PRINT 'Column DefinitionPrefix added to FLRTReportDefinition.';
+END
+ELSE
+BEGIN
+    PRINT 'Column DefinitionPrefix already exists on FLRTReportDefinition — skipping.';
+END
+GO
+
+-- Pre-populate DefinitionPrefix from the first 10 characters of DefinitionCD
+-- for all existing definitions that don't have a prefix yet.
+-- After running, review and manually set cleaner prefixes (e.g. BS, PL, CF)
+-- before enforcing the NOT NULL constraint below.
+UPDATE FLRTReportDefinition
+SET DefinitionPrefix = UPPER(LEFT(REPLACE(DefinitionCD, '_', ''), 10))
+WHERE DefinitionPrefix IS NULL
+   OR DefinitionPrefix = '';
+
+PRINT 'Pre-populated DefinitionPrefix from DefinitionCD for existing rows.';
+GO
+
+-- Verify — review these values and update any that are ambiguous before proceeding
+SELECT DefinitionID, DefinitionCD, DefinitionPrefix
+FROM FLRTReportDefinition
+ORDER BY DefinitionCD;
+GO
+
+-- ============================================================
+-- AFTER reviewing the values above and updating as needed,
+-- run the following to enforce uniqueness and NOT NULL:
+-- ============================================================
+
+-- Enforce NOT NULL once all rows have been given a valid prefix
+-- ALTER TABLE FLRTReportDefinition
+-- ALTER COLUMN DefinitionPrefix NVARCHAR(10) NOT NULL;
+
+-- Add unique constraint
+-- IF NOT EXISTS (
+--     SELECT 1 FROM sys.indexes
+--     WHERE name = 'UX_FLRTReportDefinition_Prefix'
+--       AND object_id = OBJECT_ID('FLRTReportDefinition')
+-- )
+-- BEGIN
+--     ALTER TABLE FLRTReportDefinition
+--     ADD CONSTRAINT UX_FLRTReportDefinition_Prefix UNIQUE (DefinitionPrefix);
+--     PRINT 'Unique constraint added on DefinitionPrefix.';
+-- END

--- a/SQL/02_CreateDefinitionLinkTable.sql
+++ b/SQL/02_CreateDefinitionLinkTable.sql
@@ -1,0 +1,85 @@
+-- ============================================================
+-- Script 02: Create FLRTReportDefinitionLink table
+-- Run AFTER Script 01.
+-- ============================================================
+
+IF NOT EXISTS (
+    SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_NAME = 'FLRTReportDefinitionLink'
+)
+BEGIN
+    CREATE TABLE FLRTReportDefinitionLink
+    (
+        -- Primary key (auto-identity, maps to [PXDBIdentity])
+        LinkID                  INT             IDENTITY(1,1)   NOT NULL,
+
+        -- Parent report (FK to FLRTFinancialReport.ReportID)
+        ReportID                INT             NOT NULL,
+
+        -- Linked definition (FK to FLRTReportDefinition.DefinitionID)
+        DefinitionID            INT             NOT NULL,
+
+        -- Display order in the grid (cosmetic only — no effect on calculation order)
+        DisplayOrder            INT             NOT NULL        DEFAULT 0,
+
+        -- Standard Acumatica audit fields
+        CreatedDateTime         DATETIME        NULL,
+        CreatedByID             UNIQUEIDENTIFIER NULL,
+        CreatedByScreenID       CHAR(8)         NULL,
+        LastModifiedDateTime    DATETIME        NULL,
+        LastModifiedByID        UNIQUEIDENTIFIER NULL,
+        LastModifiedByScreenID  CHAR(8)         NULL,
+        Tstamp                  ROWVERSION      NOT NULL,
+
+        CONSTRAINT PK_FLRTReportDefinitionLink PRIMARY KEY (LinkID)
+    );
+
+    PRINT 'Table FLRTReportDefinitionLink created.';
+END
+ELSE
+BEGIN
+    PRINT 'Table FLRTReportDefinitionLink already exists — skipping creation.';
+END
+GO
+
+-- Index for fast lookup of all links for a given report
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IX_FLRTReportDefinitionLink_ReportID'
+      AND object_id = OBJECT_ID('FLRTReportDefinitionLink')
+)
+BEGIN
+    CREATE INDEX IX_FLRTReportDefinitionLink_ReportID
+    ON FLRTReportDefinitionLink (ReportID);
+
+    PRINT 'Index IX_FLRTReportDefinitionLink_ReportID created.';
+END
+GO
+
+-- Prevent the same definition being linked twice to the same report
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'UX_FLRTReportDefinitionLink_ReportDef'
+      AND object_id = OBJECT_ID('FLRTReportDefinitionLink')
+)
+BEGIN
+    ALTER TABLE FLRTReportDefinitionLink
+    ADD CONSTRAINT UX_FLRTReportDefinitionLink_ReportDef
+    UNIQUE (ReportID, DefinitionID);
+
+    PRINT 'Unique constraint UX_FLRTReportDefinitionLink_ReportDef added.';
+END
+GO
+
+-- Optional foreign keys (add if referential integrity is desired)
+-- ALTER TABLE FLRTReportDefinitionLink
+-- ADD CONSTRAINT FK_DefinitionLink_Report
+--     FOREIGN KEY (ReportID) REFERENCES FLRTFinancialReport(ReportID);
+
+-- ALTER TABLE FLRTReportDefinitionLink
+-- ADD CONSTRAINT FK_DefinitionLink_Definition
+--     FOREIGN KEY (DefinitionID) REFERENCES FLRTReportDefinition(DefinitionID);
+
+-- Verify
+SELECT 'FLRTReportDefinitionLink table created successfully.' AS Result;
+GO

--- a/SQL/03_MigrateExistingDefinitions.sql
+++ b/SQL/03_MigrateExistingDefinitions.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- Script 03: Migrate existing reports from legacy DefinitionID
+--            to the new FLRTReportDefinitionLink table.
+--
+-- Run AFTER Scripts 01 and 02.
+-- Run AFTER you have reviewed and corrected DefinitionPrefix values
+-- for all existing FLRTReportDefinition rows.
+--
+-- This script is safe to run multiple times (idempotent).
+-- ============================================================
+
+-- Preview: show which reports have a legacy DefinitionID set
+-- but no rows yet in FLRTReportDefinitionLink
+SELECT
+    r.ReportID,
+    r.ReportCD,
+    r.DefinitionID,
+    d.DefinitionCD,
+    d.DefinitionPrefix
+FROM FLRTFinancialReport r
+INNER JOIN FLRTReportDefinition d ON d.DefinitionID = r.DefinitionID
+WHERE r.DefinitionID IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM FLRTReportDefinitionLink l
+      WHERE l.ReportID = r.ReportID
+  )
+ORDER BY r.ReportCD;
+GO
+
+-- Migrate: insert one FLRTReportDefinitionLink row for each report
+-- that has a legacy DefinitionID but no link rows yet.
+INSERT INTO FLRTReportDefinitionLink
+    (ReportID, DefinitionID, DisplayOrder, CreatedDateTime, LastModifiedDateTime)
+SELECT
+    r.ReportID,
+    r.DefinitionID,
+    0,                  -- DisplayOrder = 0 (first/only definition)
+    GETDATE(),
+    GETDATE()
+FROM FLRTFinancialReport r
+WHERE r.DefinitionID IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM FLRTReportDefinitionLink l
+      WHERE l.ReportID = r.ReportID
+  );
+
+PRINT CAST(@@ROWCOUNT AS VARCHAR) + ' report(s) migrated to FLRTReportDefinitionLink.';
+GO
+
+-- Verify migration result
+SELECT
+    l.LinkID,
+    l.ReportID,
+    r.ReportCD,
+    l.DefinitionID,
+    d.DefinitionCD,
+    d.DefinitionPrefix,
+    l.DisplayOrder
+FROM FLRTReportDefinitionLink l
+INNER JOIN FLRTFinancialReport r   ON r.ReportID = l.ReportID
+INNER JOIN FLRTReportDefinition d ON d.DefinitionID = l.DefinitionID
+ORDER BY r.ReportCD, l.DisplayOrder;
+GO
+
+-- ============================================================
+-- OPTIONAL: After confirming migration is correct,
+-- you may clear the legacy DefinitionID column on the report.
+-- The column is kept as a fallback and can remain populated —
+-- the generation service checks FLRTReportDefinitionLink first.
+-- ============================================================
+
+-- UPDATE FLRTFinancialReport SET DefinitionID = NULL
+-- WHERE DefinitionID IS NOT NULL
+--   AND EXISTS (
+--       SELECT 1 FROM FLRTReportDefinitionLink l WHERE l.ReportID = ReportID
+--   );
+-- PRINT 'Legacy DefinitionID cleared on migrated reports.';

--- a/SQL/04_FixOrphanedFileReference.sql
+++ b/SQL/04_FixOrphanedFileReference.sql
@@ -1,0 +1,106 @@
+-- ============================================================
+-- Script 04: Diagnose and fix orphaned file reference
+-- Addresses validation warning:
+--   "Cannot access the uploaded file.
+--    Failed to get the latest revision of the file
+--    757864dc-0595-49c3-963d-baa649bb6969"
+-- ============================================================
+
+DECLARE @BadFileID UNIQUEIDENTIFIER = '757864DC-0595-49C3-963D-BAA649BB6969';
+
+-- ============================================================
+-- SECTION 1: DIAGNOSE — run this first, review before cleanup
+-- ============================================================
+
+PRINT '--- 1. UploadFile record ---';
+SELECT FileID, [Name], CreatedDateTime, LastModifiedDateTime
+FROM UploadFile
+WHERE FileID = @BadFileID;
+
+PRINT '--- 2. UploadFileRevision records ---';
+SELECT FileID, FileRevisionID, [Size], CreatedDateTime
+FROM UploadFileRevision
+WHERE FileID = @BadFileID;
+
+PRINT '--- 3. NoteDoc references (which records link to this file) ---';
+SELECT nd.NoteID, nd.FileID
+FROM NoteDoc nd
+WHERE nd.FileID = @BadFileID;
+
+PRINT '--- 4. FLRTFinancialReport references ---';
+SELECT ReportID, ReportCD, UploadedFileID, GeneratedFileID, Noteid
+FROM FLRTFinancialReport
+WHERE UploadedFileID    = @BadFileID
+   OR GeneratedFileID   = @BadFileID;
+
+PRINT '--- 5. NoteDoc + FLRTFinancialReport join (file attached via note) ---';
+SELECT fr.ReportID, fr.ReportCD, nd.FileID, nd.NoteID
+FROM FLRTFinancialReport fr
+INNER JOIN NoteDoc nd ON nd.NoteID = fr.Noteid
+WHERE nd.FileID = @BadFileID;
+
+PRINT '--- 6. Customisation project content referencing this file ---';
+-- SYProjectContent stores items in the customisation project;
+-- some item types embed a FileID in the ProjectID / ExternalKey column.
+SELECT ProjectID, [Key], [Type], [ExternalKey], CAST(LEFT(Content, 200) AS NVARCHAR(200)) AS ContentPreview
+FROM SYProjectContent
+WHERE [ExternalKey] LIKE '%757864DC%'
+   OR CAST(Content AS NVARCHAR(MAX)) LIKE '%757864dc%';
+
+PRINT '--- 7. All SYProject projects (for context) ---';
+SELECT ProjectID, [Name], [Status]
+FROM SYProject;
+
+PRINT '--- 8. All UploadFile records with no revision (broader orphan check) ---';
+SELECT uf.FileID, uf.[Name], uf.CreatedDateTime
+FROM UploadFile uf
+WHERE NOT EXISTS (
+    SELECT 1 FROM UploadFileRevision ufr WHERE ufr.FileID = uf.FileID
+);
+
+
+-- ============================================================
+-- SECTION 2: CLEANUP — uncomment ONE of the blocks below
+-- ONLY after reviewing Section 1 output above.
+-- ============================================================
+
+/*
+-- ── Option A: Remove the NoteDoc link (safest — removes the association
+--              but keeps the UploadFile record intact) ──────────────────
+DELETE FROM NoteDoc
+WHERE FileID = @BadFileID;
+PRINT 'NoteDoc link removed.';
+*/
+
+/*
+-- ── Option B: Remove the UploadFile record and any orphaned revision ───
+-- Use this if UploadFile exists but UploadFileRevision is missing/empty.
+DELETE FROM UploadFileRevision WHERE FileID = @BadFileID;
+DELETE FROM NoteDoc            WHERE FileID = @BadFileID;
+DELETE FROM UploadFile         WHERE FileID = @BadFileID;
+PRINT 'UploadFile, UploadFileRevision, and NoteDoc entries removed.';
+*/
+
+/*
+-- ── Option C: Clear the stale fileID from FLRTFinancialReport ──────────
+-- Use this if the GUID is stored directly in UploadedFileID or
+-- GeneratedFileID on a report record that no longer needs it.
+UPDATE FLRTFinancialReport
+SET UploadedFileID    = NULL,
+    UploadedFileIDDisplay = NULL
+WHERE UploadedFileID = @BadFileID;
+
+UPDATE FLRTFinancialReport
+SET GeneratedFileID = NULL
+WHERE GeneratedFileID = @BadFileID;
+PRINT 'Stale file ID cleared from FLRTFinancialReport.';
+*/
+
+/*
+-- ── Option D: Remove the SYProjectContent entry ────────────────────────
+-- Use this if Section 6 found a row in SYProjectContent.
+-- Replace @ProjectID and @Key with the actual values from Section 6.
+DELETE FROM SYProjectContent
+WHERE [ExternalKey] LIKE '%757864DC%';
+PRINT 'SYProjectContent entry removed.';
+*/

--- a/SQL/05_DeployAllTables.sql
+++ b/SQL/05_DeployAllTables.sql
@@ -1,0 +1,394 @@
+-- =============================================
+-- FLRT Financial Report Module - Master Deployment Script
+-- Idempotent: safe to run on fresh or existing databases.
+-- For each table: CREATE if not exists, ALTER to add missing columns if exists.
+-- =============================================
+
+PRINT '======================================================'
+PRINT 'FLRT Financial Report Module - Table Deployment'
+PRINT '======================================================'
+
+-- =============================================
+-- 1. FLRTFinancialReport
+-- =============================================
+PRINT ''
+PRINT '--- FLRTFinancialReport ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND type = N'U')
+BEGIN
+    PRINT 'Creating FLRTFinancialReport...'
+
+    CREATE TABLE [dbo].[FLRTFinancialReport] (
+        [CompanyID]              [int]            NOT NULL DEFAULT(0),
+        [ReportID]               [int]            IDENTITY(1,1) NOT NULL,
+        [ReportCD]               [nvarchar](225)  NULL,
+        [Description]            [nvarchar](50)   NULL,
+        [CurrYear]               [nvarchar](4)    NULL,
+        [FinancialMonth]         [nvarchar](50)   NULL DEFAULT('12'),
+        [Branch]                 [nvarchar](10)   NULL,
+        [Organization]           [nvarchar](50)   NULL,
+        [Ledger]                 [nvarchar](20)   NULL,
+        [DefinitionID]           [int]            NULL,
+        [Status]                 [nvarchar](100)  NOT NULL DEFAULT('File not Generated'),
+        [GeneratedFileID]        [uniqueidentifier] NULL,
+        [UploadedFileID]         [uniqueidentifier] NULL,
+        [UploadedFileIDDisplay]  [nvarchar](225)  NULL,
+        [CompanyNum]             [int]            NULL,
+        [Selected]               [bit]            NULL DEFAULT(0),
+        [NoteID]                 [uniqueidentifier] NOT NULL DEFAULT(NEWID()),
+        [CreatedDateTime]        [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [CreatedByID]            [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [CreatedByScreenID]      [char](8)        NOT NULL DEFAULT('        '),
+        [LastModifiedDateTime]   [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [LastModifiedByID]       [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [LastModifiedByScreenID] [char](8)        NOT NULL DEFAULT('        '),
+        [tstamp]                 [timestamp]      NOT NULL,
+
+        CONSTRAINT [PK_FLRTFinancialReport] PRIMARY KEY CLUSTERED ([CompanyID] ASC, [ReportID] ASC)
+    )
+
+    PRINT 'FLRTFinancialReport created.'
+END
+ELSE
+BEGIN
+    PRINT 'FLRTFinancialReport exists. Checking missing columns...'
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'DefinitionID')
+    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [DefinitionID] [int] NULL
+          PRINT '  + DefinitionID' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'CompanyNum')
+    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [CompanyNum] [int] NULL
+          PRINT '  + CompanyNum' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'UploadedFileID')
+    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [UploadedFileID] [uniqueidentifier] NULL
+          PRINT '  + UploadedFileID' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'UploadedFileIDDisplay')
+    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [UploadedFileIDDisplay] [nvarchar](225) NULL
+          PRINT '  + UploadedFileIDDisplay' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'GeneratedFileID')
+    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [GeneratedFileID] [uniqueidentifier] NULL
+          PRINT '  + GeneratedFileID' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'Organization')
+    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [Organization] [nvarchar](50) NULL
+          PRINT '  + Organization' END
+
+    PRINT 'FLRTFinancialReport column check done.'
+END
+GO
+
+-- =============================================
+-- 2. FLRTTenantCredentials
+-- =============================================
+PRINT ''
+PRINT '--- FLRTTenantCredentials ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND type = N'U')
+BEGIN
+    PRINT 'Creating FLRTTenantCredentials...'
+
+    CREATE TABLE [dbo].[FLRTTenantCredentials] (
+        [CompanyID]              [int]            NOT NULL DEFAULT(0),
+        [CompanyNum]             [int]            NOT NULL,
+        [TenantName]             [nvarchar](50)   NULL,
+        [BaseURL]                [nvarchar](255)  NULL,
+        [ClientIDNew]            [nvarchar](255)  NULL,
+        [ClientSecretNew]        [nvarchar](255)  NULL,
+        [UsernameNew]            [nvarchar](255)  NULL,
+        [PasswordNew]            [nvarchar](255)  NULL,
+        [NoteID]                 [uniqueidentifier] NOT NULL DEFAULT(NEWID()),
+        [CreatedDateTime]        [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [CreatedByID]            [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [CreatedByScreenID]      [char](8)        NOT NULL DEFAULT('        '),
+        [LastModifiedDateTime]   [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [LastModifiedByID]       [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [LastModifiedByScreenID] [char](8)        NOT NULL DEFAULT('        '),
+        [tstamp]                 [timestamp]      NOT NULL,
+
+        CONSTRAINT [PK_FLRTTenantCredentials] PRIMARY KEY CLUSTERED ([CompanyID] ASC, [CompanyNum] ASC)
+    )
+
+    PRINT 'FLRTTenantCredentials created.'
+END
+ELSE
+BEGIN
+    PRINT 'FLRTTenantCredentials exists. Checking missing columns...'
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'BaseURL')
+    BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [BaseURL] [nvarchar](255) NULL
+          PRINT '  + BaseURL' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'ClientIDNew')
+    BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [ClientIDNew] [nvarchar](255) NULL
+          PRINT '  + ClientIDNew' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'ClientSecretNew')
+    BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [ClientSecretNew] [nvarchar](255) NULL
+          PRINT '  + ClientSecretNew' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'UsernameNew')
+    BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [UsernameNew] [nvarchar](255) NULL
+          PRINT '  + UsernameNew' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'PasswordNew')
+    BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [PasswordNew] [nvarchar](255) NULL
+          PRINT '  + PasswordNew' END
+
+    -- Migrate: add CompanyID column and rebuild PK if CompanyID is missing
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'CompanyID')
+    BEGIN
+        PRINT '  Migrating: adding CompanyID to FLRTTenantCredentials...'
+
+        -- Drop existing PK (name may be auto-generated, so look it up dynamically)
+        DECLARE @pkName NVARCHAR(128)
+        SELECT @pkName = name FROM sys.key_constraints
+            WHERE parent_object_id = OBJECT_ID('FLRTTenantCredentials') AND type = 'PK'
+        EXEC('ALTER TABLE [dbo].[FLRTTenantCredentials] DROP CONSTRAINT [' + @pkName + ']')
+
+        -- Add CompanyID column (nullable first so existing rows get default 0)
+        ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [CompanyID] [int] NOT NULL DEFAULT(0)
+
+        -- Set CompanyID = CompanyNum for all existing rows (they are the same value)
+        -- EXEC used for deferred name resolution (column added in same IF block)
+        EXEC('UPDATE [dbo].[FLRTTenantCredentials] SET [CompanyID] = [CompanyNum]')
+
+        -- Recreate PK with CompanyID as first component
+        ALTER TABLE [dbo].[FLRTTenantCredentials]
+            ADD CONSTRAINT [PK_FLRTTenantCredentials] PRIMARY KEY CLUSTERED ([CompanyID] ASC, [CompanyNum] ASC)
+
+        PRINT '  + CompanyID (PK rebuilt)'
+    END
+
+    PRINT 'FLRTTenantCredentials column check done.'
+END
+GO
+
+-- =============================================
+-- 3. FLRTReportDefinition
+-- =============================================
+PRINT ''
+PRINT '--- FLRTReportDefinition ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND type = N'U')
+BEGIN
+    PRINT 'Creating FLRTReportDefinition...'
+
+    CREATE TABLE [dbo].[FLRTReportDefinition] (
+        [CompanyID]              [int]            NOT NULL DEFAULT(0),
+        [DefinitionID]           [int]            IDENTITY(1,1) NOT NULL,
+        [DefinitionCD]           [nvarchar](50)   NOT NULL,
+        [DefinitionPrefix]       [nvarchar](10)   NULL,
+        [Description]            [nvarchar](255)  NULL,
+        [ReportType]             [nvarchar](10)   NULL DEFAULT('BS'),
+        [IsActive]               [bit]            NULL DEFAULT(1),
+        [GIName]                 [nvarchar](100)  NULL DEFAULT('TrialBalance'),
+        [AccountColumn]          [nvarchar](100)  NULL DEFAULT('Account'),
+        [TypeColumn]             [nvarchar](100)  NULL DEFAULT('Type'),
+        [BeginningBalColumn]     [nvarchar](100)  NULL DEFAULT('BeginningBalance'),
+        [EndingBalColumn]        [nvarchar](100)  NULL DEFAULT('EndingBalance'),
+        [DebitColumn]            [nvarchar](100)  NULL DEFAULT('Debit'),
+        [CreditColumn]           [nvarchar](100)  NULL DEFAULT('Credit'),
+        [RoundingLevel]          [nvarchar](10)   NULL DEFAULT('UNITS'),
+        [DecimalPlaces]          [int]            NULL DEFAULT(0),
+        [CreatedDateTime]        [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [CreatedByID]            [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [CreatedByScreenID]      [char](8)        NOT NULL DEFAULT('        '),
+        [LastModifiedDateTime]   [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [LastModifiedByID]       [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [LastModifiedByScreenID] [char](8)        NOT NULL DEFAULT('        '),
+        [tstamp]                 [timestamp]      NOT NULL,
+
+        CONSTRAINT [PK_FLRTReportDefinition] PRIMARY KEY CLUSTERED ([CompanyID] ASC, [DefinitionCD] ASC)
+    )
+
+    PRINT 'FLRTReportDefinition created.'
+END
+ELSE
+BEGIN
+    PRINT 'FLRTReportDefinition exists. Checking missing columns...'
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'DefinitionPrefix')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [DefinitionPrefix] [nvarchar](10) NULL
+          PRINT '  + DefinitionPrefix' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'GIName')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [GIName] [nvarchar](100) NULL DEFAULT('TrialBalance')
+          PRINT '  + GIName' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'AccountColumn')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [AccountColumn] [nvarchar](100) NULL DEFAULT('Account')
+          PRINT '  + AccountColumn' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'TypeColumn')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [TypeColumn] [nvarchar](100) NULL DEFAULT('Type')
+          PRINT '  + TypeColumn' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'BeginningBalColumn')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [BeginningBalColumn] [nvarchar](100) NULL DEFAULT('BeginningBalance')
+          PRINT '  + BeginningBalColumn' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'EndingBalColumn')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [EndingBalColumn] [nvarchar](100) NULL DEFAULT('EndingBalance')
+          PRINT '  + EndingBalColumn' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'DebitColumn')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [DebitColumn] [nvarchar](100) NULL DEFAULT('Debit')
+          PRINT '  + DebitColumn' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'CreditColumn')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [CreditColumn] [nvarchar](100) NULL DEFAULT('Credit')
+          PRINT '  + CreditColumn' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'RoundingLevel')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [RoundingLevel] [nvarchar](10) NULL DEFAULT('UNITS')
+          PRINT '  + RoundingLevel' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'DecimalPlaces')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [DecimalPlaces] [int] NULL DEFAULT(0)
+          PRINT '  + DecimalPlaces' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinition]') AND name = 'IsActive')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinition] ADD [IsActive] [bit] NULL DEFAULT(1)
+          PRINT '  + IsActive' END
+
+    PRINT 'FLRTReportDefinition column check done.'
+END
+GO
+
+-- =============================================
+-- 4. FLRTReportDefinitionLink
+-- =============================================
+PRINT ''
+PRINT '--- FLRTReportDefinitionLink ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinitionLink]') AND type = N'U')
+BEGIN
+    PRINT 'Creating FLRTReportDefinitionLink...'
+
+    CREATE TABLE [dbo].[FLRTReportDefinitionLink] (
+        [CompanyID]              [int]            NOT NULL DEFAULT(0),
+        [LinkID]                 [int]            IDENTITY(1,1) NOT NULL,
+        [ReportID]               [int]            NULL,
+        [DefinitionID]           [int]            NULL,
+        [DisplayOrder]           [int]            NULL DEFAULT(0),
+        [CreatedDateTime]        [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [CreatedByID]            [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [CreatedByScreenID]      [char](8)        NOT NULL DEFAULT('        '),
+        [LastModifiedDateTime]   [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [LastModifiedByID]       [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [LastModifiedByScreenID] [char](8)        NOT NULL DEFAULT('        '),
+        [tstamp]                 [timestamp]      NOT NULL,
+
+        CONSTRAINT [PK_FLRTReportDefinitionLink] PRIMARY KEY CLUSTERED ([CompanyID] ASC, [LinkID] ASC)
+    )
+
+    PRINT 'FLRTReportDefinitionLink created.'
+END
+ELSE
+BEGIN
+    PRINT 'FLRTReportDefinitionLink exists. Checking missing columns...'
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinitionLink]') AND name = 'DisplayOrder')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinitionLink] ADD [DisplayOrder] [int] NULL DEFAULT(0)
+          PRINT '  + DisplayOrder' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinitionLink]') AND name = 'ReportID')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinitionLink] ADD [ReportID] [int] NULL
+          PRINT '  + ReportID' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportDefinitionLink]') AND name = 'DefinitionID')
+    BEGIN ALTER TABLE [dbo].[FLRTReportDefinitionLink] ADD [DefinitionID] [int] NULL
+          PRINT '  + DefinitionID' END
+
+    PRINT 'FLRTReportDefinitionLink column check done.'
+END
+GO
+
+-- =============================================
+-- 5. FLRTReportLineItem
+-- =============================================
+PRINT ''
+PRINT '--- FLRTReportLineItem ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportLineItem]') AND type = N'U')
+BEGIN
+    PRINT 'Creating FLRTReportLineItem...'
+
+    CREATE TABLE [dbo].[FLRTReportLineItem] (
+        [CompanyID]              [int]            NOT NULL DEFAULT(0),
+        [LineID]                 [int]            IDENTITY(1,1) NOT NULL,
+        [DefinitionID]           [int]            NULL,
+        [SortOrder]              [int]            NULL DEFAULT(0),
+        [LineCode]               [nvarchar](100)  NULL,
+        [Description]            [nvarchar](255)  NULL,
+        [LineType]               [nvarchar](20)   NULL DEFAULT('ACCOUNT'),
+        [AccountFrom]            [nvarchar](50)   NULL,
+        [AccountTo]              [nvarchar](50)   NULL,
+        [AccountTypeFilter]      [nvarchar](5)    NULL,
+        [SignRule]               [nvarchar](10)   NULL DEFAULT('ASIS'),
+        [BalanceType]            [nvarchar](10)   NULL DEFAULT('ENDING'),
+        [ParentLineCode]         [nvarchar](100)  NULL,
+        [Formula]                [nvarchar](500)  NULL,
+        [IsVisible]              [bit]            NULL DEFAULT(1),
+        [SubaccountFilter]       [nvarchar](30)   NULL,
+        [BranchFilter]           [nvarchar](30)   NULL,
+        [OrganizationFilter]     [nvarchar](30)   NULL,
+        [LedgerFilter]           [nvarchar](20)   NULL,
+        [NoteID]                 [uniqueidentifier] NULL,
+        [CreatedDateTime]        [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [CreatedByID]            [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [CreatedByScreenID]      [char](8)        NOT NULL DEFAULT('        '),
+        [LastModifiedDateTime]   [datetime]       NOT NULL DEFAULT(GETDATE()),
+        [LastModifiedByID]       [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
+        [LastModifiedByScreenID] [char](8)        NOT NULL DEFAULT('        '),
+        [tstamp]                 [timestamp]      NOT NULL,
+
+        CONSTRAINT [PK_FLRTReportLineItem] PRIMARY KEY CLUSTERED ([CompanyID] ASC, [LineID] ASC)
+    )
+
+    PRINT 'FLRTReportLineItem created.'
+END
+ELSE
+BEGIN
+    PRINT 'FLRTReportLineItem exists. Checking missing columns...'
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportLineItem]') AND name = 'SubaccountFilter')
+    BEGIN ALTER TABLE [dbo].[FLRTReportLineItem] ADD [SubaccountFilter] [nvarchar](30) NULL
+          PRINT '  + SubaccountFilter' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportLineItem]') AND name = 'BranchFilter')
+    BEGIN ALTER TABLE [dbo].[FLRTReportLineItem] ADD [BranchFilter] [nvarchar](30) NULL
+          PRINT '  + BranchFilter' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportLineItem]') AND name = 'OrganizationFilter')
+    BEGIN ALTER TABLE [dbo].[FLRTReportLineItem] ADD [OrganizationFilter] [nvarchar](30) NULL
+          PRINT '  + OrganizationFilter' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportLineItem]') AND name = 'LedgerFilter')
+    BEGIN ALTER TABLE [dbo].[FLRTReportLineItem] ADD [LedgerFilter] [nvarchar](20) NULL
+          PRINT '  + LedgerFilter' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportLineItem]') AND name = 'IsVisible')
+    BEGIN ALTER TABLE [dbo].[FLRTReportLineItem] ADD [IsVisible] [bit] NULL DEFAULT(1)
+          PRINT '  + IsVisible' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportLineItem]') AND name = 'Formula')
+    BEGIN ALTER TABLE [dbo].[FLRTReportLineItem] ADD [Formula] [nvarchar](500) NULL
+          PRINT '  + Formula' END
+
+    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTReportLineItem]') AND name = 'NoteID')
+    BEGIN ALTER TABLE [dbo].[FLRTReportLineItem] ADD [NoteID] [uniqueidentifier] NULL
+          PRINT '  + NoteID' END
+
+    PRINT 'FLRTReportLineItem column check done.'
+END
+GO
+
+PRINT ''
+PRINT '======================================================'
+PRINT 'Deployment complete.'
+PRINT '======================================================'


### PR DESCRIPTION
… linking

- Add FLRTReportDefinitionLink DAC to support multiple definitions per report
- Add DefinitionPrefix field to FLRTReportDefinition for namespaced placeholder keys
- Mark legacy DefinitionID field on FLRTFinancialReport as hidden for backward compatibility
- Update FLRTFinancialReportMaint to manage definition links via child grid
- Update FLRTReportDefinitionMaint to handle prefix validation and uniqueness
- Enhance ReportCalculationEngine to resolve cross-definition formula dependencies
- Update ReportGenerationService to merge prefixed placeholders from multiple definitions
- Add SQL migration scripts for schema updates and data migration
- Add comprehensive user documentation for multi-definition report workflows
- Enables reports to combine multiple financial definitions with cross-definition formulas