### PR TITLE
feat(presentation): Add slide generation and presentation API integra…

### DIFF
--- a/FinancialReport/DAC/FLRTFinancialReport.cs
+++ b/FinancialReport/DAC/FLRTFinancialReport.cs
@@ -190,7 +190,7 @@ namespace FinancialReport
     #endregion
 
     #region Status
-        [PXDBString(20, IsUnicode = true)]
+        [PXDBString(50, IsUnicode = true)]
     [PXDefault(ReportStatus.Pending)] // Default status
     [PXUIField(DisplayName = "Status", IsReadOnly = true)]
     [PXStringList(new string[]
@@ -210,6 +210,52 @@ namespace FinancialReport
     public virtual string Status { get; set; }
     public abstract class status : PX.Data.BQL.BqlString.Field<status> { }
         #endregion
+
+    #region PresentationTitle
+    [PXDBString(500, IsUnicode = true)]
+    [PXUIField(DisplayName = "Presentation Title")]
+    public virtual string PresentationTitle { get; set; }
+    public abstract class presentationTitle : PX.Data.BQL.BqlString.Field<presentationTitle> { }
+    #endregion
+
+    #region GammaTemplateId
+    [PXDBString(100, IsUnicode = true)]
+    [PXUIField(DisplayName = "Gamma Template ID")]
+    public virtual string GammaTemplateId { get; set; }
+    public abstract class gammaTemplateId : PX.Data.BQL.BqlString.Field<gammaTemplateId> { }
+    #endregion
+
+    #region PresentationDescription
+    [PXDBString(2000, IsUnicode = true)]
+    [PXUIField(DisplayName = "Presentation Description")]
+    public virtual string PresentationDescription { get; set; }
+    public abstract class presentationDescription : PX.Data.BQL.BqlString.Field<presentationDescription> { }
+    #endregion
+
+    #region SlideGeneratedFileID
+    [PXDBGuid]
+    [PXUIField(DisplayName = "Slide File ID", Visible = false)]
+    public virtual Guid? SlideGeneratedFileID { get; set; }
+    public abstract class slideGeneratedFileID : PX.Data.BQL.BqlGuid.Field<slideGeneratedFileID> { }
+    #endregion
+
+    #region PresentationMarkdown
+    [PXDBText(IsUnicode = true)]
+    [PXUIField(DisplayName = "Presentation Markdown")]
+    public virtual string PresentationMarkdown { get; set; }
+    public abstract class presentationMarkdown : PX.Data.BQL.BqlString.Field<presentationMarkdown> { }
+    #endregion
+
+    #region SlideStatus
+    [PXDBString(50, IsUnicode = true)]
+    [PXDefault(ReportStatus.Pending, PersistingCheck = PXPersistingCheck.Nothing)]
+    [PXUIField(DisplayName = "Presentation Status", IsReadOnly = true)]
+    [PXStringList(
+        new string[] { ReportStatus.Pending, ReportStatus.InProgress, ReportStatus.Completed, ReportStatus.Failed },
+        new string[] { "Pending", "In Progress", "Ready to Download", "Failed" })]
+    public virtual string SlideStatus { get; set; }
+    public abstract class slideStatus : PX.Data.BQL.BqlString.Field<slideStatus> { }
+    #endregion
 
     #region Report Status
     public static class ReportStatus

--- a/FinancialReport/DAC/FLRTTenantCredentials.cs
+++ b/FinancialReport/DAC/FLRTTenantCredentials.cs
@@ -113,5 +113,26 @@ namespace FinancialReport
         { }
         #endregion
 
+        #region AlaiApiKey
+        [PXRSACryptString]
+        [PXUIField(DisplayName = "Alai API Key")]
+        public virtual string AlaiApiKey { get; set; }
+        public abstract class alaiApiKey : PX.Data.BQL.BqlString.Field<alaiApiKey> { }
+        #endregion
+
+        #region SlidesGptApiKey
+        [PXRSACryptString]
+        [PXUIField(DisplayName = "SlidesGPT API Key")]
+        public virtual string SlidesGptApiKey { get; set; }
+        public abstract class slidesGptApiKey : PX.Data.BQL.BqlString.Field<slidesGptApiKey> { }
+        #endregion
+
+        #region GammaApiKey
+        [PXRSACryptString]
+        [PXUIField(DisplayName = "Gamma API Key")]
+        public virtual string GammaApiKey { get; set; }
+        public abstract class gammaApiKey : PX.Data.BQL.BqlString.Field<gammaApiKey> { }
+        #endregion
+
     }
 }

--- a/FinancialReport/FinancialReport.csproj
+++ b/FinancialReport/FinancialReport.csproj
@@ -92,6 +92,11 @@
     <Compile Include="Helper\GIColumnMapping.cs" />
     <Compile Include="Helper\GIColumnSelectorAttribute.cs" />
     <Compile Include="Helper\RoundingSettings.cs" />
+    <Compile Include="Services\AlaiApiService.cs" />
+    <Compile Include="Services\MarkdownBuilderService.cs" />
+    <Compile Include="Services\SlideGenerationService.cs" />
+    <Compile Include="Services\SlidesGptApiService.cs" />
+    <Compile Include="Services\GammaApiService.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml">

--- a/FinancialReport/Graph/FLRTFinancialReportMaint.cs
+++ b/FinancialReport/Graph/FLRTFinancialReportMaint.cs
@@ -89,10 +89,15 @@ namespace FinancialReport
             var row = (FLRTFinancialReport)e.Row;
             if (row == null) return;
 
-            bool isInProgress = row.Status == ReportStatus.InProgress;
+            bool isInProgress      = row.Status == ReportStatus.InProgress;
+            bool isSlideInProgress = row.SlideStatus == ReportStatus.InProgress;
+
             PXUIFieldAttribute.SetEnabled(cache, row, !isInProgress);
             GenerateReport.SetEnabled(!isInProgress);
             DownloadReport.SetEnabled(!isInProgress);
+            GeneratePresentation.SetEnabled(!isInProgress && !isSlideInProgress);
+            DownloadPresentation.SetVisible(true);
+            DownloadPresentation.SetEnabled(row.SlideGeneratedFileID != null);
         }
 
         protected void FLRTFinancialReport_RowPersisting(PXCache cache, PXRowPersistingEventArgs e)
@@ -133,6 +138,11 @@ namespace FinancialReport
         public PXAction<FLRTFinancialReport> GenerateReport = null!; // Initialized by PXGraph framework
         public PXAction<FLRTFinancialReport> DownloadReport = null!; // Initialized by PXGraph framework
         public PXAction<FLRTFinancialReport> ResetStatus = null!; // Initialized by PXGraph framework
+        public PXAction<FLRTFinancialReport> GeneratePresentation = null!; // Initialized by PXGraph framework
+        public PXAction<FLRTFinancialReport> DownloadPresentation = null!; // Initialized by PXGraph framework
+        public PXAction<FLRTFinancialReport> PreviewMarkdown = null!; // Initialized by PXGraph framework
+        public PXAction<FLRTFinancialReport> GenerateSlidesGpt = null!; // Initialized by PXGraph framework
+        public PXAction<FLRTFinancialReport> GenerateGamma = null!; // Initialized by PXGraph framework
 
         [PXButton(CommitChanges = false)]
         [PXUIField(DisplayName = "Generate Report")]
@@ -325,6 +335,437 @@ namespace FinancialReport
 
             return adapter.Get();
         }
+
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Generate Presentation", MapEnableRights = PXCacheRights.Update, Visible = true)]
+        protected virtual System.Collections.IEnumerable generatePresentation(PXAdapter adapter)
+        {
+            var selectedRecord = FinancialReport.Current;
+
+            if (selectedRecord == null) throw new PXException(Messages.PleaseSelectTemplate);
+            if (selectedRecord.ReportID == null) throw new PXException(Messages.NoReportSelected);
+            if (selectedRecord.SlideStatus == ReportStatus.InProgress) throw new PXException(Messages.SlideGenerationInProgress);
+            if (string.IsNullOrWhiteSpace(selectedRecord.PresentationTitle)) throw new PXException(Messages.PresentationTitleRequired);
+
+            int? companyID = GetCompanyIDFromDB(selectedRecord.ReportID);
+            string tenantName = MapCompanyIDToTenantName(companyID);
+            AcumaticaCredentials tenantCredentials = CredentialProvider.GetCredentials(tenantName);
+
+            // Retrieve Alai API key from tenant credentials record
+            FLRTTenantCredentials tenantCreds = PXSelect<FLRTTenantCredentials,
+                Where<FLRTTenantCredentials.companyNum, Equal<Required<FLRTTenantCredentials.companyNum>>>>
+                .Select(this, companyID);
+
+            if (tenantCreds == null || string.IsNullOrWhiteSpace(tenantCreds.AlaiApiKey))
+                throw new PXException(Messages.AlaiApiKeyNotConfigured);
+
+            string alaiApiKey = tenantCreds.AlaiApiKey;
+
+            var authService = new AuthService(
+                tenantCredentials.BaseURL,
+                tenantCredentials.ClientId,
+                tenantCredentials.ClientSecret,
+                tenantCredentials.Username,
+                tenantCredentials.Password
+            );
+
+            // Mark slide as In Progress and save
+            selectedRecord.SlideStatus = ReportStatus.InProgress;
+            FinancialReport.Update(selectedRecord);
+            Actions.PressSave();
+
+            int? reportID = selectedRecord.ReportID;
+
+            PXLongOperation.StartOperation(this, () =>
+            {
+                var reportGraph = PXGraph.CreateInstance<FLRTFinancialReportMaint>();
+                FLRTFinancialReport dbRecord = null;
+
+                try
+                {
+                    dbRecord = PXSelect<FLRTFinancialReport,
+                        Where<FLRTFinancialReport.reportID, Equal<Required<FLRTFinancialReport.reportID>>>>
+                        .SelectSingleBound(reportGraph, null, reportID);
+
+                    if (dbRecord == null) throw new PXException(Messages.FailedToRetrieveFile);
+
+                    Guid fileID;
+
+                    if (!string.IsNullOrWhiteSpace(dbRecord.PresentationMarkdown))
+                    {
+                        // Use the stored (possibly edited) markdown — skip GL data fetch
+                        PXTrace.WriteInformation($"[Slide] Using stored markdown ({dbRecord.PresentationMarkdown.Length} chars).");
+
+                        string slideTitle = !string.IsNullOrWhiteSpace(dbRecord.PresentationTitle)
+                            ? dbRecord.PresentationTitle
+                            : $"{dbRecord.ReportCD} Presentation";
+
+                        var alaiService = new AlaiApiService(alaiApiKey);
+                        byte[] pptBytes = alaiService.GeneratePresentation(dbRecord.PresentationMarkdown, slideTitle);
+
+                        string fileName = $"{dbRecord.ReportCD}_Presentation_{DateTime.Now:yyyyMMdd_HHmm}.pptx";
+                        var fileService = new FileService(reportGraph);
+                        fileID = fileService.SaveGeneratedDocument(fileName, pptBytes, dbRecord);
+                    }
+                    else
+                    {
+                        // No stored markdown — generate from GL data from scratch
+                        authService.AuthenticateAndGetToken();
+                        PXTrace.WriteInformation($"[Slide] Authenticated for {tenantName}.");
+
+                        var slideService = new SlideGenerationService(reportGraph, dbRecord, authService, alaiApiKey, tenantName);
+                        fileID = slideService.Execute();
+                    }
+
+                    dbRecord.SlideGeneratedFileID = fileID;
+                    dbRecord.SlideStatus          = ReportStatus.Completed;
+                    reportGraph.FinancialReport.Update(dbRecord);
+                    reportGraph.Actions.PressSave();
+
+                    PXTrace.WriteInformation($"[Slide] Presentation generation completed. FileID: {fileID}");
+                }
+                catch (Exception ex)
+                {
+                    PXTrace.WriteError($"[Slide] Presentation generation failed: {ex}");
+                    if (dbRecord != null)
+                    {
+                        dbRecord.SlideStatus = ReportStatus.Failed;
+                        reportGraph.FinancialReport.Update(dbRecord);
+                        try { reportGraph.Actions.PressSave(); } catch { }
+                    }
+                    throw;
+                }
+                finally
+                {
+                    authService?.Logout();
+                }
+            });
+
+            return adapter.Get();
+        }
+
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Preview Markdown", MapEnableRights = PXCacheRights.Update, Visible = true)]
+        protected virtual System.Collections.IEnumerable previewMarkdown(PXAdapter adapter)
+        {
+            var selectedRecord = FinancialReport.Current;
+
+            if (selectedRecord == null) throw new PXException(Messages.PleaseSelectTemplate);
+            if (selectedRecord.ReportID == null) throw new PXException(Messages.NoReportSelected);
+
+            int? companyID = GetCompanyIDFromDB(selectedRecord.ReportID);
+            string tenantName = MapCompanyIDToTenantName(companyID);
+            AcumaticaCredentials tenantCredentials = CredentialProvider.GetCredentials(tenantName);
+
+            FLRTTenantCredentials tenantCreds = PXSelect<FLRTTenantCredentials,
+                Where<FLRTTenantCredentials.companyNum, Equal<Required<FLRTTenantCredentials.companyNum>>>>
+                .Select(this, companyID);
+
+            var authService = new AuthService(
+                tenantCredentials.BaseURL,
+                tenantCredentials.ClientId,
+                tenantCredentials.ClientSecret,
+                tenantCredentials.Username,
+                tenantCredentials.Password
+            );
+
+            int? reportID = selectedRecord.ReportID;
+
+            PXLongOperation.StartOperation(this, () =>
+            {
+                var reportGraph = PXGraph.CreateInstance<FLRTFinancialReportMaint>();
+                FLRTFinancialReport dbRecord = null;
+
+                try
+                {
+                    dbRecord = PXSelect<FLRTFinancialReport,
+                        Where<FLRTFinancialReport.reportID, Equal<Required<FLRTFinancialReport.reportID>>>>
+                        .SelectSingleBound(reportGraph, null, reportID);
+
+                    if (dbRecord == null) throw new PXException(Messages.FailedToRetrieveFile);
+
+                    authService.AuthenticateAndGetToken();
+
+                    var slideService = new SlideGenerationService(reportGraph, dbRecord, authService, "preview-only", tenantName);
+                    Guid fileID = slideService.BuildMarkdownPreview();
+
+                    // Save markdown text into the record field so user can edit before generating
+                    dbRecord.PresentationMarkdown = slideService.LastGeneratedMarkdown;
+
+                    // Touch the record so PressSave flushes the NoteDoc link and saves the markdown field
+                    reportGraph.FinancialReport.Update(dbRecord);
+                    reportGraph.Actions.PressSave();
+
+                    PXTrace.WriteInformation($"[Slide] Markdown preview saved. FileID={fileID}");
+                }
+                catch (Exception ex)
+                {
+                    PXTrace.WriteError($"[Slide] Markdown preview failed: {ex}");
+                    throw;
+                }
+                finally
+                {
+                    authService?.Logout();
+                }
+            });
+
+            return adapter.Get();
+        }
+
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Generate SlidesGPT", MapEnableRights = PXCacheRights.Update, Visible = true)]
+        protected virtual System.Collections.IEnumerable generateSlidesGpt(PXAdapter adapter)
+        {
+            var selectedRecord = FinancialReport.Current;
+
+            if (selectedRecord == null) throw new PXException(Messages.PleaseSelectTemplate);
+            if (selectedRecord.ReportID == null) throw new PXException(Messages.NoReportSelected);
+            if (selectedRecord.SlideStatus == ReportStatus.InProgress) throw new PXException(Messages.SlideGenerationInProgress);
+            if (string.IsNullOrWhiteSpace(selectedRecord.PresentationTitle)) throw new PXException(Messages.PresentationTitleRequired);
+
+            int? companyID = GetCompanyIDFromDB(selectedRecord.ReportID);
+            string tenantName = MapCompanyIDToTenantName(companyID);
+            AcumaticaCredentials tenantCredentials = CredentialProvider.GetCredentials(tenantName);
+
+            FLRTTenantCredentials tenantCreds = PXSelect<FLRTTenantCredentials,
+                Where<FLRTTenantCredentials.companyNum, Equal<Required<FLRTTenantCredentials.companyNum>>>>
+                .Select(this, companyID);
+
+            if (tenantCreds == null || string.IsNullOrWhiteSpace(tenantCreds.SlidesGptApiKey))
+                throw new PXException(Messages.SlidesGptApiKeyNotConfigured);
+
+            string slidesGptApiKey = tenantCreds.SlidesGptApiKey;
+
+            var authService = new AuthService(
+                tenantCredentials.BaseURL,
+                tenantCredentials.ClientId,
+                tenantCredentials.ClientSecret,
+                tenantCredentials.Username,
+                tenantCredentials.Password
+            );
+
+            // Mark slide as In Progress and save
+            selectedRecord.SlideStatus = ReportStatus.InProgress;
+            FinancialReport.Update(selectedRecord);
+            Actions.PressSave();
+
+            int? reportID = selectedRecord.ReportID;
+
+            PXLongOperation.StartOperation(this, () =>
+            {
+                var reportGraph = PXGraph.CreateInstance<FLRTFinancialReportMaint>();
+                FLRTFinancialReport dbRecord = null;
+
+                try
+                {
+                    dbRecord = PXSelect<FLRTFinancialReport,
+                        Where<FLRTFinancialReport.reportID, Equal<Required<FLRTFinancialReport.reportID>>>>
+                        .SelectSingleBound(reportGraph, null, reportID);
+
+                    if (dbRecord == null) throw new PXException(Messages.FailedToRetrieveFile);
+
+                    Guid fileID;
+                    string prompt;
+
+                    if (!string.IsNullOrWhiteSpace(dbRecord.PresentationMarkdown))
+                    {
+                        // Use the stored (possibly edited) markdown
+                        PXTrace.WriteInformation($"[SlidesGPT] Using stored markdown ({dbRecord.PresentationMarkdown.Length} chars).");
+                        prompt = dbRecord.PresentationMarkdown;
+                    }
+                    else
+                    {
+                        // Generate markdown from GL data
+                        authService.AuthenticateAndGetToken();
+                        PXTrace.WriteInformation($"[SlidesGPT] Authenticated for {tenantName}.");
+                        var slideService = new SlideGenerationService(reportGraph, dbRecord, authService, "preview-only", tenantName);
+                        slideService.BuildMarkdownPreview();
+                        prompt = slideService.LastGeneratedMarkdown;
+
+                        // Persist generated markdown for future reference
+                        dbRecord.PresentationMarkdown = prompt;
+                    }
+
+                    string slideTitle = !string.IsNullOrWhiteSpace(dbRecord.PresentationTitle)
+                        ? dbRecord.PresentationTitle
+                        : $"{dbRecord.ReportCD} Presentation";
+
+                    PXTrace.WriteInformation($"[SlidesGPT] Calling SlidesGPT API (prompt: {prompt.Length} chars). First 200: {prompt.Substring(0, Math.Min(200, prompt.Length))}");
+                    var slidesGptService = new SlidesGptApiService(slidesGptApiKey);
+                    byte[] pptBytes = slidesGptService.GeneratePresentation(prompt);
+                    PXTrace.WriteInformation($"[SlidesGPT] API returned {pptBytes?.Length ?? 0} bytes.");
+
+                    string fileName = $"{dbRecord.ReportCD}_SlidesGPT_{DateTime.Now:yyyyMMdd_HHmm}.pptx";
+                    PXTrace.WriteInformation($"[SlidesGPT] Saving file: {fileName}");
+                    var fileService = new FileService(reportGraph);
+                    fileID = fileService.SaveGeneratedDocument(fileName, pptBytes, dbRecord);
+
+                    dbRecord.SlideGeneratedFileID = fileID;
+                    dbRecord.SlideStatus          = ReportStatus.Completed;
+                    reportGraph.FinancialReport.Update(dbRecord);
+                    reportGraph.Actions.PressSave();
+
+                    PXTrace.WriteInformation($"[SlidesGPT] Done. FileID: {fileID}");
+                }
+                catch (Exception ex)
+                {
+                    PXTrace.WriteError($"[SlidesGPT] Generation failed: {ex}");
+                    if (dbRecord != null)
+                    {
+                        dbRecord.SlideStatus = ReportStatus.Failed;
+                        reportGraph.FinancialReport.Update(dbRecord);
+                        try { reportGraph.Actions.PressSave(); } catch { }
+                    }
+                    throw;
+                }
+                finally
+                {
+                    authService?.Logout();
+                }
+            });
+
+            return adapter.Get();
+        }
+
+        [PXButton(CommitChanges = true)]
+        [PXUIField(DisplayName = "Generate Gamma", MapEnableRights = PXCacheRights.Update, Visible = true)]
+        protected virtual System.Collections.IEnumerable generateGamma(PXAdapter adapter)
+        {
+            var selectedRecord = FinancialReport.Current;
+
+            if (selectedRecord == null) throw new PXException(Messages.PleaseSelectTemplate);
+            if (selectedRecord.ReportID == null) throw new PXException(Messages.NoReportSelected);
+            if (selectedRecord.SlideStatus == ReportStatus.InProgress) throw new PXException(Messages.SlideGenerationInProgress);
+            if (string.IsNullOrWhiteSpace(selectedRecord.PresentationTitle)) throw new PXException(Messages.PresentationTitleRequired);
+
+            int? companyID = GetCompanyIDFromDB(selectedRecord.ReportID);
+            string tenantName = MapCompanyIDToTenantName(companyID);
+            AcumaticaCredentials tenantCredentials = CredentialProvider.GetCredentials(tenantName);
+
+            FLRTTenantCredentials tenantCreds = PXSelect<FLRTTenantCredentials,
+                Where<FLRTTenantCredentials.companyNum, Equal<Required<FLRTTenantCredentials.companyNum>>>>
+                .Select(this, companyID);
+
+            if (tenantCreds == null || string.IsNullOrWhiteSpace(tenantCreds.GammaApiKey))
+                throw new PXException(Messages.GammaApiKeyNotConfigured);
+
+            string gammaApiKey = tenantCreds.GammaApiKey;
+
+            var authService = new AuthService(
+                tenantCredentials.BaseURL,
+                tenantCredentials.ClientId,
+                tenantCredentials.ClientSecret,
+                tenantCredentials.Username,
+                tenantCredentials.Password
+            );
+
+            // Mark slide as In Progress and save
+            selectedRecord.SlideStatus = ReportStatus.InProgress;
+            FinancialReport.Update(selectedRecord);
+            Actions.PressSave();
+
+            int? reportID = selectedRecord.ReportID;
+
+            PXLongOperation.StartOperation(this, () =>
+            {
+                var reportGraph = PXGraph.CreateInstance<FLRTFinancialReportMaint>();
+                FLRTFinancialReport dbRecord = null;
+
+                try
+                {
+                    dbRecord = PXSelect<FLRTFinancialReport,
+                        Where<FLRTFinancialReport.reportID, Equal<Required<FLRTFinancialReport.reportID>>>>
+                        .SelectSingleBound(reportGraph, null, reportID);
+
+                    if (dbRecord == null) throw new PXException(Messages.FailedToRetrieveFile);
+
+                    Guid fileID;
+                    string markdown;
+
+                    if (!string.IsNullOrWhiteSpace(dbRecord.PresentationMarkdown))
+                    {
+                        PXTrace.WriteInformation($"[Gamma] Using stored markdown ({dbRecord.PresentationMarkdown.Length} chars).");
+                        markdown = dbRecord.PresentationMarkdown;
+                    }
+                    else
+                    {
+                        // Generate markdown from GL data
+                        authService.AuthenticateAndGetToken();
+                        PXTrace.WriteInformation($"[Gamma] Authenticated for {tenantName}.");
+                        var slideService = new SlideGenerationService(reportGraph, dbRecord, authService, "preview-only", tenantName);
+                        slideService.BuildMarkdownPreview();
+                        markdown = slideService.LastGeneratedMarkdown;
+
+                        // Persist generated markdown
+                        dbRecord.PresentationMarkdown = markdown;
+                    }
+
+                    string slideTitle = !string.IsNullOrWhiteSpace(dbRecord.PresentationTitle)
+                        ? dbRecord.PresentationTitle
+                        : $"{dbRecord.ReportCD} Presentation";
+
+                    var gammaService = new GammaApiService(gammaApiKey);
+                    byte[] pptBytes;
+
+                    if (!string.IsNullOrWhiteSpace(dbRecord.GammaTemplateId))
+                    {
+                        PXTrace.WriteInformation($"[Gamma] Using template ID: {dbRecord.GammaTemplateId} (markdown: {markdown.Length} chars).");
+                        pptBytes = gammaService.GeneratePresentationFromTemplate(markdown, dbRecord.GammaTemplateId);
+                    }
+                    else
+                    {
+                        PXTrace.WriteInformation($"[Gamma] Submitting generation (markdown: {markdown.Length} chars). Title: {slideTitle}");
+                        pptBytes = gammaService.GeneratePresentation(markdown, slideTitle);
+                    }
+
+                    PXTrace.WriteInformation($"[Gamma] Downloaded {pptBytes.Length} bytes.");
+
+                    string fileName = $"{dbRecord.ReportCD}_Gamma_{DateTime.Now:yyyyMMdd_HHmm}.pptx";
+                    var fileService = new FileService(reportGraph);
+                    fileID = fileService.SaveGeneratedDocument(fileName, pptBytes, dbRecord);
+
+                    dbRecord.SlideGeneratedFileID = fileID;
+                    dbRecord.SlideStatus          = ReportStatus.Completed;
+                    reportGraph.FinancialReport.Update(dbRecord);
+                    reportGraph.Actions.PressSave();
+
+                    PXTrace.WriteInformation($"[Gamma] Done. FileID: {fileID}");
+                }
+                catch (Exception ex)
+                {
+                    PXTrace.WriteError($"[Gamma] Generation failed: {ex}");
+                    if (dbRecord != null)
+                    {
+                        dbRecord.SlideStatus = ReportStatus.Failed;
+                        reportGraph.FinancialReport.Update(dbRecord);
+                        try { reportGraph.Actions.PressSave(); } catch { }
+                    }
+                    throw;
+                }
+                finally
+                {
+                    authService?.Logout();
+                }
+            });
+
+            return adapter.Get();
+        }
+
+        [PXButton]
+        [PXUIField(DisplayName = "Download Presentation", MapEnableRights = PXCacheRights.Select, Visible = true)]
+        protected virtual System.Collections.IEnumerable downloadPresentation(PXAdapter adapter)
+        {
+            var selectedRecord = FinancialReport.Current;
+
+            if (selectedRecord == null)
+                throw new PXException(Messages.NoRecordIsSelected);
+
+            if (selectedRecord.SlideGeneratedFileID == null)
+                throw new PXException(Messages.NoGeneratedPresentation);
+
+            throw new PXRedirectToFileException(selectedRecord.SlideGeneratedFileID.Value, true);
+        }
+
         #endregion
 
         #region Public Helper Methods

--- a/FinancialReport/Helper/Messages.cs
+++ b/FinancialReport/Helper/Messages.cs
@@ -107,6 +107,17 @@ namespace FinancialReport
         public const string CircularDependencyDetected = "Circular dependency detected in report definitions. The following line codes form a cycle and cannot be resolved: {0}. Please revise the formulas to break the cycle.";
 
         // ==================================================
+        // SLIDE / PRESENTATION GENERATION MESSAGES
+        // ==================================================
+        public const string SlideGenerationInProgress = "A presentation generation process is already running for this report.";
+        public const string PresentationTitleRequired = "Please enter a Presentation Title before generating a presentation.";
+        public const string AlaiApiKeyNotConfigured = "Alai API Key is not configured. Please enter your Alai API Key in the Tenant Credentials screen.";
+        public const string SlidesGptApiKeyNotConfigured = "SlidesGPT API Key is not configured. Please enter your SlidesGPT API Key in the Tenant Credentials screen.";
+        public const string GammaApiKeyNotConfigured = "Gamma API Key is not configured. Please enter your Gamma API Key in the Tenant Credentials screen.";
+        public const string NoGeneratedPresentation = "No presentation is available for download. Please generate a presentation first.";
+        public const string MarkdownPreviewComplete = "Markdown preview saved. Download it from the Files panel (paperclip icon).";
+
+        // ==================================================
         // GI & COLUMN MAPPING MESSAGES
         // ==================================================
         public const string GINameRequired = "Generic Inquiry Name is required to detect columns.";

--- a/FinancialReport/Services/AlaiApiService.cs
+++ b/FinancialReport/Services/AlaiApiService.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PX.Data;
+
+namespace FinancialReport.Services
+{
+    /// <summary>
+    /// Calls the Alai API (getalai.com) to generate a PowerPoint presentation from markdown text.
+    /// Flow: POST /generations → poll GET /generations/{id} → download .ppt bytes.
+    /// </summary>
+    public class AlaiApiService
+    {
+        private const string BaseUrl = "https://slides-api.getalai.com/api/v1";
+        private const int PollIntervalSeconds = 5;
+        private const int MaxWaitSeconds = 180;
+
+        private readonly HttpClient _httpClient;
+
+        public AlaiApiService(string apiKey)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentNullException(nameof(apiKey));
+
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+            _httpClient.Timeout = TimeSpan.FromMinutes(5);
+        }
+
+        /// <summary>
+        /// Submits a generation request, polls until complete, downloads and returns the .ppt bytes.
+        /// </summary>
+        public byte[] GeneratePresentation(string inputText, string title, string tone = "professional", string slideRange = "6-10")
+        {
+            string generationId = SubmitGeneration(inputText, title, tone, slideRange);
+            PXTrace.WriteInformation($"[Alai] Generation submitted. ID: {generationId}");
+
+            byte[] pptBytes = PollForCompletionAndDownload(generationId);
+            PXTrace.WriteInformation($"[Alai] Generation complete. Received {pptBytes.Length} bytes.");
+
+            return pptBytes;
+        }
+
+        private string SubmitGeneration(string inputText, string title, string tone, string slideRange)
+        {
+            var payload = new
+            {
+                input_text = inputText,
+                presentation_options = new
+                {
+                    title        = title,
+                    slide_range  = slideRange,
+                    tone         = tone,
+                    export_formats = new[] { "ppt" }
+                }
+            };
+
+            string json    = JsonConvert.SerializeObject(payload);
+            var content    = new StringContent(json, Encoding.UTF8, "application/json");
+            var response   = _httpClient.PostAsync($"{BaseUrl}/generations", content).Result;
+            string body    = response.Content.ReadAsStringAsync().Result;
+
+            if (!response.IsSuccessStatusCode)
+                throw new PXException($"[Alai] Generation request failed ({(int)response.StatusCode}): {body}");
+
+            var result       = JObject.Parse(body);
+            string generationId = result["generation_id"]?.ToString();
+
+            if (string.IsNullOrEmpty(generationId))
+                throw new PXException($"[Alai] No generation_id returned. Response: {body}");
+
+            return generationId;
+        }
+
+        private byte[] PollForCompletionAndDownload(string generationId)
+        {
+            int elapsed = 0;
+
+            while (elapsed < MaxWaitSeconds)
+            {
+                Thread.Sleep(PollIntervalSeconds * 1000);
+                elapsed += PollIntervalSeconds;
+
+                var response = _httpClient.GetAsync($"{BaseUrl}/generations/{generationId}").Result;
+                string body  = response.Content.ReadAsStringAsync().Result;
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    PXTrace.WriteWarning($"[Alai] Poll returned {(int)response.StatusCode}: {body}");
+                    continue;
+                }
+
+                var result = JObject.Parse(body);
+                string status = result["status"]?.ToString()?.ToUpperInvariant() ?? "";
+                PXTrace.WriteInformation($"[Alai] Poll status: {status} ({elapsed}s elapsed)");
+
+                if (status == "COMPLETED" || status == "SUCCESS" || status == "DONE")
+                {
+                    string presentationId = result["presentation_id"]?.ToString();
+                    PXTrace.WriteInformation($"[Alai] Complete. presentation_id={presentationId}");
+
+                    // 1. Try a dedicated download endpoint using the presentation_id
+                    if (!string.IsNullOrEmpty(presentationId))
+                    {
+                        byte[] fileBytes = TryDownloadByPresentationId(presentationId);
+                        if (fileBytes != null) return fileBytes;
+                    }
+
+                    // 2. Try to find a direct binary URL in the response
+                    string directUrl = ExtractDirectFileUrl(result);
+                    if (!string.IsNullOrEmpty(directUrl))
+                        return DownloadFile(directUrl);
+
+                    // 3. Nothing worked
+                    throw new PXException($"[Alai] Generation complete but could not download the file. " +
+                        $"presentation_id={presentationId}. Response: {body}");
+                }
+
+                if (status == "FAILED" || status == "ERROR")
+                    throw new PXException($"[Alai] Presentation generation failed: {body}");
+            }
+
+            throw new PXException($"[Alai] Generation timed out after {MaxWaitSeconds} seconds. Generation ID: {generationId}");
+        }
+
+        /// <summary>
+        /// Tries known Alai download endpoints for a given presentation_id.
+        /// Returns null if none succeed.
+        /// </summary>
+        private byte[] TryDownloadByPresentationId(string presentationId)
+        {
+            string[] endpoints = new[]
+            {
+                $"{BaseUrl}/presentations/{presentationId}/download?format=pptx",
+                $"{BaseUrl}/presentations/{presentationId}/download?format=ppt",
+                $"{BaseUrl}/presentations/{presentationId}/download",
+                $"{BaseUrl}/presentations/{presentationId}/export?format=pptx",
+                $"{BaseUrl}/presentations/{presentationId}",
+            };
+
+            foreach (string endpoint in endpoints)
+            {
+                try
+                {
+                    var resp = _httpClient.GetAsync(endpoint).Result;
+                    if (!resp.IsSuccessStatusCode) continue;
+
+                    string contentType = resp.Content.Headers.ContentType?.MediaType ?? "";
+                    PXTrace.WriteInformation($"[Alai] Download endpoint {endpoint} → {(int)resp.StatusCode} {contentType}");
+
+                    // Accept binary content types
+                    if (contentType.Contains("application/vnd") ||
+                        contentType.Contains("application/octet") ||
+                        contentType.Contains("application/zip") ||
+                        contentType.Contains("application/x-zip"))
+                    {
+                        return resp.Content.ReadAsByteArrayAsync().Result;
+                    }
+
+                    // If JSON, look for a nested download URL
+                    if (contentType.Contains("json"))
+                    {
+                        string jsonBody = resp.Content.ReadAsStringAsync().Result;
+                        try
+                        {
+                            var json = JObject.Parse(jsonBody);
+                            string nestedUrl = json["download_url"]?.ToString()
+                                ?? json["url"]?.ToString()
+                                ?? json["pptx_url"]?.ToString()
+                                ?? json["ppt_url"]?.ToString();
+                            if (!string.IsNullOrEmpty(nestedUrl) && !nestedUrl.Contains("/view/"))
+                                return DownloadFile(nestedUrl);
+                        }
+                        catch { }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    PXTrace.WriteWarning($"[Alai] Endpoint {endpoint} failed: {ex.Message}");
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Extracts a direct binary file URL from the completed generation response.
+        /// Skips view/browser URLs (e.g. /view/).
+        /// </summary>
+        private string ExtractDirectFileUrl(JObject result)
+        {
+            // Top-level direct URL fields
+            foreach (string field in new[] { "download_url", "ppt_url", "pptx_url", "file_url" })
+            {
+                string val = result[field]?.ToString();
+                if (!string.IsNullOrEmpty(val) && !val.Contains("/view/")) return val;
+            }
+
+            // Nested under "formats" — iterate all format entries
+            var formats = result["formats"] as JObject ?? result["export_formats"] as JObject;
+            if (formats != null)
+            {
+                foreach (var kvp in formats)
+                {
+                    // Format value may be a plain string URL
+                    if (kvp.Value?.Type == JTokenType.String)
+                    {
+                        string val = kvp.Value.ToString();
+                        if (!string.IsNullOrEmpty(val) && !val.Contains("/view/")) return val;
+                    }
+
+                    // Or a nested object: { "status": "completed", "url": "..." }
+                    var formatObj = kvp.Value as JObject;
+                    if (formatObj != null)
+                    {
+                        string val = formatObj["url"]?.ToString()
+                            ?? formatObj["download_url"]?.ToString();
+                        if (!string.IsNullOrEmpty(val) && !val.Contains("/view/")) return val;
+                    }
+                }
+            }
+
+            // task_result shape
+            var taskResult = result["task_result"] as JObject;
+            string trUrl = taskResult?["url"]?.ToString() ?? taskResult?["ppt_url"]?.ToString();
+            if (!string.IsNullOrEmpty(trUrl) && !trUrl.Contains("/view/")) return trUrl;
+
+            return null;
+        }
+
+        private byte[] DownloadFile(string url)
+        {
+            var response = _httpClient.GetAsync(url).Result;
+            if (!response.IsSuccessStatusCode)
+                throw new PXException($"[Alai] File download failed ({(int)response.StatusCode}) from URL: {url}");
+
+            return response.Content.ReadAsByteArrayAsync().Result;
+        }
+    }
+}

--- a/FinancialReport/Services/GammaApiService.cs
+++ b/FinancialReport/Services/GammaApiService.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PX.Data;
+
+namespace FinancialReport.Services
+{
+    /// <summary>
+    /// Calls the Gamma API (public-api.gamma.app) to generate a PPTX presentation from a text prompt.
+    /// Standard flow: POST /generations → poll GET /generations/{id} until completed → download PPTX from exportUrl.
+    /// Template flow:  POST /generations/from-template → same polling → download PPTX from exportUrl.
+    /// </summary>
+    public class GammaApiService
+    {
+        private const string BaseUrl       = "https://public-api.gamma.app/v1.0";
+        private const int    PollIntervalMs = 5000;  // 5 seconds between polls
+        private const int    MaxPolls       = 60;    // max 5 minutes
+
+        private readonly HttpClient _httpClient;
+
+        public GammaApiService(string apiKey)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentNullException(nameof(apiKey));
+
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("X-API-KEY", apiKey);
+            _httpClient.Timeout = TimeSpan.FromMinutes(10);
+        }
+
+        /// <summary>
+        /// Generates a PPTX using the standard /generations endpoint (no template).
+        /// </summary>
+        public byte[] GeneratePresentation(string financialMarkdown, string presentationTitle)
+        {
+            string generationId = SubmitGeneration(financialMarkdown, presentationTitle);
+            PXTrace.WriteInformation($"[Gamma] Generation submitted. ID: {generationId}");
+
+            string exportUrl = PollUntilCompleted(generationId);
+            PXTrace.WriteInformation($"[Gamma] Generation completed. Downloading PPTX from: {exportUrl}");
+
+            byte[] pptBytes = DownloadFile(exportUrl);
+            PXTrace.WriteInformation($"[Gamma] Downloaded {pptBytes.Length} bytes.");
+
+            return pptBytes;
+        }
+
+        /// <summary>
+        /// Generates a PPTX using /generations/from-template.
+        /// gammaTemplateId is the gammaId from the template URL: gamma.app/docs/{gammaId}
+        /// </summary>
+        public byte[] GeneratePresentationFromTemplate(string financialMarkdown, string gammaTemplateId)
+        {
+            string generationId = SubmitGenerationFromTemplate(financialMarkdown, gammaTemplateId);
+            PXTrace.WriteInformation($"[Gamma] Template generation submitted. ID: {generationId}");
+
+            string exportUrl = PollUntilCompleted(generationId);
+            PXTrace.WriteInformation($"[Gamma] Template generation completed. Downloading PPTX from: {exportUrl}");
+
+            byte[] pptBytes = DownloadFile(exportUrl);
+            PXTrace.WriteInformation($"[Gamma] Downloaded {pptBytes.Length} bytes.");
+
+            return pptBytes;
+        }
+
+        private string SubmitGenerationFromTemplate(string prompt, string gammaTemplateId)
+        {
+            var payload = new
+            {
+                gammaId  = gammaTemplateId,
+                prompt   = prompt,
+                exportAs = "pptx"
+            };
+
+            string json    = JsonConvert.SerializeObject(payload);
+            var content    = new StringContent(json, Encoding.UTF8, "application/json");
+            var response   = _httpClient.PostAsync($"{BaseUrl}/generations/from-template", content).Result;
+            string body    = response.Content.ReadAsStringAsync().Result;
+
+            if (!response.IsSuccessStatusCode)
+                throw new PXException($"[Gamma] Template generation request failed ({(int)response.StatusCode}): {body}");
+
+            var result   = JObject.Parse(body);
+            string genId = result["generationId"]?.ToString();
+
+            if (string.IsNullOrEmpty(genId))
+                throw new PXException($"[Gamma] No generationId returned from template endpoint. Response: {body}");
+
+            return genId;
+        }
+
+        private string SubmitGeneration(string inputText, string title)
+        {
+            var payload = new
+            {
+                inputText            = inputText,
+                textMode             = "generate",
+                format               = "presentation",
+                exportAs             = "pptx",
+                numCards             = 12,
+                additionalInstructions = $"Professional CFO-level financial presentation titled '{title}' for senior management and board members. Highlight key trends, risks, and strategic recommendations.",
+                textOptions          = new
+                {
+                    amount   = "detailed",
+                    tone     = "Professional, executive-level",
+                    audience = "Senior management and board members"
+                },
+                imageOptions         = new
+                {
+                    source = "pictographic"
+                }
+            };
+
+            string json    = JsonConvert.SerializeObject(payload);
+            var content    = new StringContent(json, Encoding.UTF8, "application/json");
+            var response   = _httpClient.PostAsync($"{BaseUrl}/generations", content).Result;
+            string body    = response.Content.ReadAsStringAsync().Result;
+
+            if (!response.IsSuccessStatusCode)
+                throw new PXException($"[Gamma] Generation request failed ({(int)response.StatusCode}): {body}");
+
+            var result       = JObject.Parse(body);
+            string genId     = result["generationId"]?.ToString();
+
+            if (string.IsNullOrEmpty(genId))
+                throw new PXException($"[Gamma] No generationId returned. Response: {body}");
+
+            return genId;
+        }
+
+        private string PollUntilCompleted(string generationId)
+        {
+            for (int i = 0; i < MaxPolls; i++)
+            {
+                Thread.Sleep(PollIntervalMs);
+
+                var response   = _httpClient.GetAsync($"{BaseUrl}/generations/{generationId}").Result;
+                string body    = response.Content.ReadAsStringAsync().Result;
+
+                if (!response.IsSuccessStatusCode)
+                    throw new PXException($"[Gamma] Poll failed ({(int)response.StatusCode}): {body}");
+
+                var result = JObject.Parse(body);
+                string status = result["status"]?.ToString();
+
+                PXTrace.WriteInformation($"[Gamma] Poll {i + 1}/{MaxPolls} — status: {status}");
+
+                if (status == "completed")
+                {
+                    // exportUrl contains the PPTX file URL when exportAs:"pptx" was requested.
+                    // gammaUrl is the viewer URL (gamma.app/docs/...) — not downloadable directly.
+                    string exportUrl = result["exportUrl"]?.ToString();
+                    if (string.IsNullOrEmpty(exportUrl))
+                        throw new PXException($"[Gamma] Generation completed but no exportUrl found. Response: {body}");
+                    return exportUrl;
+                }
+
+                if (status == "failed")
+                {
+                    string errorMsg = result["error"]?["message"]?.ToString() ?? "Unknown error";
+                    throw new PXException($"[Gamma] Generation failed: {errorMsg}");
+                }
+            }
+
+            throw new PXException($"[Gamma] Timed out after {MaxPolls * PollIntervalMs / 1000} seconds waiting for generation to complete.");
+        }
+
+        private byte[] DownloadFile(string url)
+        {
+            var response = _httpClient.GetAsync(url).Result;
+
+            if (!response.IsSuccessStatusCode)
+                throw new PXException($"[Gamma] File download failed ({(int)response.StatusCode}). URL: {url}");
+
+            return response.Content.ReadAsByteArrayAsync().Result;
+        }
+    }
+}

--- a/FinancialReport/Services/MarkdownBuilderService.cs
+++ b/FinancialReport/Services/MarkdownBuilderService.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FinancialReport.Helper;
+
+namespace FinancialReport.Services
+{
+    /// <summary>
+    /// Builds a structured markdown string from calculated financial report data.
+    /// The markdown is used as the input_text payload for the Alai presentation API.
+    ///
+    /// Output format:
+    ///   # [Title]
+    ///   [Description]
+    ///   Organization | Branch | Ledger | Period context
+    ///   ---
+    ///   ## [Line Description]
+    ///   - CY value, PM value, MoM change, PY value, YoY change
+    ///   (repeated per visible line item across all definitions)
+    /// </summary>
+    public class MarkdownBuilderService
+    {
+        private static readonly string[] MonthNames =
+        {
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December"
+        };
+
+        /// <summary>
+        /// Builds the complete markdown string from the report header, line items, and calculated results.
+        /// </summary>
+        /// <param name="report">The FLRTFinancialReport record (provides period, org, branch, ledger, title, description).</param>
+        /// <param name="definitions">Each definition paired with its ordered line items.</param>
+        /// <param name="results">Dictionary from ReportCalculationEngine.CalculateAll() — keyed PREFIX_LINECODE_CY/PM/PY.</param>
+        public string Build(
+            FLRTFinancialReport report,
+            List<(ReportCalculationEngine.DefinitionLink DefLink, List<FLRTReportLineItem> Items)> definitions,
+            Dictionary<string, string> results)
+        {
+            // ── Derive period labels ───────────────────────────────────────────────
+            int month = int.TryParse(report.FinancialMonth, out int m) ? m : 12;
+            int year  = int.TryParse(report.CurrYear,       out int y) ? y : DateTime.Now.Year;
+
+            int prevMonth     = month == 1 ? 12 : month - 1;
+            int prevMonthYear = month == 1 ? year - 1 : year;
+
+            string cyLabel = $"{MonthNames[month - 1]} {year}";
+            string pmLabel = $"{MonthNames[prevMonth - 1]} {prevMonthYear}";
+            string pyLabel = $"{MonthNames[month - 1]} {year - 1}";
+
+            var sb = new StringBuilder();
+
+            // ── Header ─────────────────────────────────────────────────────────────
+            string title = !string.IsNullOrWhiteSpace(report.PresentationTitle)
+                ? report.PresentationTitle
+                : $"{cyLabel} Financial Report";
+
+            sb.AppendLine($"# {title}");
+
+            if (!string.IsNullOrWhiteSpace(report.PresentationDescription))
+                sb.AppendLine(report.PresentationDescription);
+
+            sb.AppendLine();
+            sb.AppendLine($"Organization: {report.Organization ?? "N/A"} | Branch: {report.Branch ?? "N/A"} | Ledger: {report.Ledger ?? "N/A"}");
+            sb.AppendLine($"Reporting Period: {cyLabel}");
+            sb.AppendLine($"Month-over-Month: {cyLabel} vs {pmLabel}");
+            sb.AppendLine($"Year-over-Year: {cyLabel} vs {pyLabel}");
+            sb.AppendLine();
+            sb.AppendLine("---");
+            sb.AppendLine();
+
+            // ── Line items ─────────────────────────────────────────────────────────
+            foreach (var (defLink, items) in definitions)
+            {
+                var visibleItems = items.Where(l => l.IsVisible == true).ToList();
+                if (!visibleItems.Any()) continue;
+
+                foreach (var line in visibleItems)
+                {
+                    string keyBase = $"{defLink.Prefix}_{line.LineCode}";
+                    string cyVal   = GetValue(results, keyBase + "_" + Constants.CurrentYearSuffix);
+                    string pmVal   = GetValue(results, keyBase + "_" + Constants.PreviousMonthSuffix);
+                    string pyVal   = GetValue(results, keyBase + "_" + Constants.PreviousYearSuffix);
+
+                    string label = !string.IsNullOrWhiteSpace(line.Description)
+                        ? line.Description
+                        : line.LineCode;
+
+                    decimal cyDec = ParseDecimal(cyVal);
+                    decimal pmDec = ParseDecimal(pmVal);
+                    decimal pyDec = ParseDecimal(pyVal);
+
+                    decimal momChange = cyDec - pmDec;
+                    decimal yoyChange = cyDec - pyDec;
+
+                    // Credit-balance accounts (equity, liability, expenses) are stored as negative.
+                    // For those, a positive raw change means the balance shrank — which is a decrease
+                    // in real terms. Negate the displayed change so the narrative reads correctly:
+                    // e.g. Equity (9.5M) vs (10.2M): raw change = +641K → displayed as -641K (-6.3%).
+                    bool isCredit = cyDec < 0;
+                    decimal displayMom = isCredit ? -momChange : momChange;
+                    decimal displayYoy = isCredit ? -yoyChange : yoyChange;
+
+                    decimal momBase = pmDec != 0 ? Math.Abs(pmDec) : 0;
+                    decimal yoyBase = pyDec != 0 ? Math.Abs(pyDec) : 0;
+
+                    string momPct = momBase != 0 ? $" ({displayMom / momBase * 100:N1}%)" : "";
+                    string yoyPct = yoyBase != 0 ? $" ({displayYoy / yoyBase * 100:N1}%)" : "";
+
+                    sb.AppendLine($"## {label}");
+                    sb.AppendLine($"- {cyLabel}: {cyVal}");
+                    sb.AppendLine($"- {pmLabel}: {pmVal}");
+                    sb.AppendLine($"- Month-on-Month Change: {displayMom:N0}{momPct}");
+                    sb.AppendLine($"- {pyLabel}: {pyVal}");
+                    sb.AppendLine($"- Year-on-Year Change: {displayYoy:N0}{yoyPct}");
+                    sb.AppendLine();
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private string GetValue(Dictionary<string, string> results, string key)
+        {
+            if (results != null && results.TryGetValue(key, out string val) && !string.IsNullOrEmpty(val))
+                return val;
+            return "0";
+        }
+
+        private decimal ParseDecimal(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return 0m;
+            // Strip formatting characters that may come from the engine (commas, spaces)
+            string cleaned = value.Replace(",", "").Replace(" ", "").Trim();
+            // Handle accounting format: (1234) means -1234
+            if (cleaned.StartsWith("(") && cleaned.EndsWith(")"))
+                cleaned = "-" + cleaned.Substring(1, cleaned.Length - 2);
+            return decimal.TryParse(cleaned, out decimal result) ? result : 0m;
+        }
+    }
+}

--- a/FinancialReport/Services/SlideGenerationService.cs
+++ b/FinancialReport/Services/SlideGenerationService.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FinancialReport.Helper;
+using PX.Data;
+using PX.Data.BQL;
+using PX.Data.BQL.Fluent;
+
+namespace FinancialReport.Services
+{
+    /// <summary>
+    /// Orchestrates the end-to-end generation of a PowerPoint presentation via the Alai API.
+    ///
+    /// Mirrors ReportGenerationService in its data-fetching pipeline (same GL calls,
+    /// same calculation engine) but replaces the Word template step with:
+    ///   1. MarkdownBuilderService  — formats results into structured markdown
+    ///   2. AlaiApiService          — submits markdown to Alai, polls, downloads .ppt
+    ///   3. FileService             — attaches the .ppt to the Acumatica record
+    ///
+    /// BuildMarkdownPreview() stops after step 7 and saves the markdown as a .txt
+    /// file so the user can review what will be sent to Alai before committing.
+    /// </summary>
+    public class SlideGenerationService
+    {
+        private readonly FLRTFinancialReportMaint _graph;
+        private readonly FLRTFinancialReport _currentRecord;
+        private readonly AuthService _authService;
+        private readonly string _alaiApiKey;
+        private readonly string _tenantName;
+        private readonly FileService _fileService;
+
+        public SlideGenerationService(
+            FLRTFinancialReportMaint graph,
+            FLRTFinancialReport record,
+            AuthService authService,
+            string alaiApiKey,
+            string tenantName)
+        {
+            _graph         = graph         ?? throw new ArgumentNullException(nameof(graph));
+            _currentRecord = record        ?? throw new ArgumentNullException(nameof(record));
+            _authService   = authService   ?? throw new ArgumentNullException(nameof(authService));
+            _alaiApiKey    = alaiApiKey    ?? throw new ArgumentNullException(nameof(alaiApiKey));
+            _tenantName    = tenantName    ?? throw new ArgumentNullException(nameof(tenantName));
+            _fileService   = new FileService(_graph);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // PUBLIC PROPERTIES
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Set after BuildMarkdownPreview() completes. Callers can read this to
+        /// persist the markdown text to the record's PresentationMarkdown field.
+        /// </summary>
+        public string LastGeneratedMarkdown { get; private set; }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // PUBLIC ENTRY POINTS
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Runs the full pipeline and returns the FileID of the saved .ppt attachment.
+        /// </summary>
+        public Guid Execute()
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            var (markdown, definitionsWithItems) = PrepareMarkdown(stopwatch);
+
+            // ── 8. Call Alai API ───────────────────────────────────────────────────
+            string slideTitle = !string.IsNullOrWhiteSpace(_currentRecord.PresentationTitle)
+                ? _currentRecord.PresentationTitle
+                : $"{_currentRecord.ReportCD} Presentation";
+
+            var alaiService = new AlaiApiService(_alaiApiKey);
+            byte[] pptBytes = alaiService.GeneratePresentation(markdown, slideTitle);
+            PXTrace.WriteInformation($"[Slide] Presentation received — {pptBytes.Length} bytes in {stopwatch.ElapsedMilliseconds}ms");
+
+            // ── 9. Save .ppt as attachment ─────────────────────────────────────────
+            string fileName = $"{_currentRecord.ReportCD}_Presentation_{DateTime.Now:yyyyMMdd_HHmm}.pptx";
+            Guid fileID = _fileService.SaveGeneratedDocument(fileName, pptBytes, _currentRecord);
+
+            stopwatch.Stop();
+            PXTrace.WriteInformation($"[Slide] Presentation saved with FileID {fileID} — total {stopwatch.ElapsedMilliseconds}ms");
+
+            return fileID;
+        }
+
+        /// <summary>
+        /// Runs steps 1–7 only (no Alai call).
+        /// Saves the generated markdown as a .txt file attached to the record and returns its FileID.
+        /// Use this to review the exact payload before sending to Alai.
+        /// </summary>
+        public Guid BuildMarkdownPreview()
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            var (markdown, _) = PrepareMarkdown(stopwatch);
+            LastGeneratedMarkdown = markdown;
+
+            // Write full markdown to trace for additional visibility
+            PXTrace.WriteInformation($"[Slide] Markdown preview:\n{markdown}");
+
+            // Save as downloadable .txt attachment
+            byte[] txtBytes = Encoding.UTF8.GetBytes(markdown);
+            string fileName = $"{_currentRecord.ReportCD}_MarkdownPreview_{DateTime.Now:yyyyMMdd_HHmm}.txt";
+            Guid fileID = _fileService.SaveGeneratedDocument(fileName, txtBytes, _currentRecord);
+
+            stopwatch.Stop();
+            PXTrace.WriteInformation($"[Slide] Markdown preview saved with FileID {fileID} — total {stopwatch.ElapsedMilliseconds}ms");
+
+            return fileID;
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SHARED PIPELINE (steps 1–7)
+        // ─────────────────────────────────────────────────────────────────────
+
+        private (string Markdown, List<(ReportCalculationEngine.DefinitionLink DefLink, List<FLRTReportLineItem> Items)> Definitions) PrepareMarkdown(
+            System.Diagnostics.Stopwatch stopwatch)
+        {
+            // ── 1. Load definition links ───────────────────────────────────────────
+            GIColumnMapping columnMapping = null;
+            var definitionLinks = new List<ReportCalculationEngine.DefinitionLink>();
+
+            var linkedDefs = SelectFrom<FLRTReportDefinitionLink>
+                .InnerJoin<FLRTReportDefinition>
+                    .On<FLRTReportDefinition.definitionID.IsEqual<FLRTReportDefinitionLink.definitionID>>
+                .Where<FLRTReportDefinitionLink.reportID.IsEqual<@P.AsInt>>
+                .OrderBy<FLRTReportDefinitionLink.displayOrder.Asc>
+                .View.Select(_graph, _currentRecord.ReportID)
+                .Cast<PXResult<FLRTReportDefinitionLink, FLRTReportDefinition>>()
+                .ToList();
+
+            if (linkedDefs.Any())
+            {
+                var firstDef = linkedDefs.First().GetItem<FLRTReportDefinition>();
+                columnMapping = GIColumnMapping.FromDefinition(firstDef);
+
+                foreach (var result in linkedDefs)
+                {
+                    var def = result.GetItem<FLRTReportDefinition>();
+                    definitionLinks.Add(new ReportCalculationEngine.DefinitionLink
+                    {
+                        DefinitionID = def.DefinitionID!.Value,
+                        Prefix       = def.DefinitionPrefix,
+                        Rounding     = RoundingSettings.FromDefinition(def)
+                    });
+                }
+            }
+            else if (_currentRecord.DefinitionID != null)
+            {
+                var reportDef = SelectFrom<FLRTReportDefinition>
+                    .Where<FLRTReportDefinition.definitionID.IsEqual<@P.AsInt>>
+                    .View.Select(_graph, _currentRecord.DefinitionID)
+                    .TopFirst;
+
+                if (reportDef != null)
+                {
+                    columnMapping = GIColumnMapping.FromDefinition(reportDef);
+                    definitionLinks.Add(new ReportCalculationEngine.DefinitionLink
+                    {
+                        DefinitionID = reportDef.DefinitionID!.Value,
+                        Prefix       = reportDef.DefinitionPrefix,
+                        Rounding     = RoundingSettings.FromDefinition(reportDef)
+                    });
+                }
+            }
+
+            if (!definitionLinks.Any())
+                throw new PXException("No report definitions linked. Please add at least one definition on the Report Definitions tab before generating a presentation.");
+
+            // ── 2. Collect line items per definition ───────────────────────────────
+            var definitionsWithItems = new List<(ReportCalculationEngine.DefinitionLink DefLink, List<FLRTReportLineItem> Items)>();
+
+            foreach (var defLink in definitionLinks)
+            {
+                var items = SelectFrom<FLRTReportLineItem>
+                    .Where<FLRTReportLineItem.definitionID.IsEqual<@P.AsInt>>
+                    .OrderBy<FLRTReportLineItem.sortOrder.Asc>
+                    .View.Select(_graph, defLink.DefinitionID)
+                    .RowCast<FLRTReportLineItem>()
+                    .ToList();
+
+                definitionsWithItems.Add((defLink, items));
+            }
+
+            // ── 3. Validate descriptions ───────────────────────────────────────────
+            var missingDesc = definitionsWithItems
+                .SelectMany(d => d.Items)
+                .Where(li => li.IsVisible == true && string.IsNullOrWhiteSpace(li.Description))
+                .Select(li => li.LineCode)
+                .ToList();
+
+            if (missingDesc.Any())
+                throw new PXException($"The following visible line items are missing descriptions: {string.Join(", ", missingDesc)}. Please fill in all descriptions before generating a presentation.");
+
+            // ── 4. Set up periods ──────────────────────────────────────────────────
+            string currYear      = _currentRecord.CurrYear ?? DateTime.Now.ToString("yyyy");
+            string selectedMonth = _currentRecord.FinancialMonth ?? "12";
+            int currYearInt      = int.TryParse(currYear, out int py) ? py : DateTime.Now.Year;
+            int selectedMonthInt = int.TryParse(selectedMonth, out int pm) ? pm : 12;
+
+            string prevYear            = (currYearInt - 1).ToString();
+            string prevYearPrior       = (currYearInt - 2).ToString();
+            string selectedPeriod      = $"{selectedMonth}{currYear}";
+            string prevYearPeriod      = $"{selectedMonth}{prevYear}";
+            string prevYearPriorPeriod = $"{selectedMonth}{prevYearPrior}";
+
+            int prevMonthInt   = selectedMonthInt == 1 ? 12 : selectedMonthInt - 1;
+            int prevMonthYear  = selectedMonthInt == 1 ? currYearInt - 1 : currYearInt;
+            string prevMonthPeriod = $"{prevMonthInt:D2}{prevMonthYear}";
+
+            PXTrace.WriteInformation($"[Slide] Periods — CY:{selectedPeriod}, PY:{prevYearPeriod}, PM:{prevMonthPeriod}");
+
+            // ── 5. Fetch GL data ───────────────────────────────────────────────────
+            var dataService = new FinancialDataService(_authService, _tenantName, columnMapping);
+
+            var taskCY    = Task.Run(() => dataService.FetchAllApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, selectedPeriod,      false));
+            var taskPY    = Task.Run(() => dataService.FetchAllApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, prevYearPeriod,      false));
+            var taskPrior = Task.Run(() => dataService.FetchAllApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, prevYearPriorPeriod, false));
+            var taskPM    = Task.Run(() => dataService.FetchAllApiData(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, prevMonthPeriod,     false));
+            var taskJanCY = Task.Run(() => dataService.FetchJanuaryBeginningBalance(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, currYear));
+            var taskJanPY = Task.Run(() => dataService.FetchJanuaryBeginningBalance(_currentRecord.Branch, _currentRecord.Organization, _currentRecord.Ledger, prevYear));
+
+            Task.WhenAll(taskCY, taskPY, taskPrior, taskPM, taskJanCY, taskJanPY).Wait();
+            PXTrace.WriteInformation($"[Slide] GL data fetched in {stopwatch.ElapsedMilliseconds}ms");
+
+            // ── 6. Run calculation engine ──────────────────────────────────────────
+            var engine  = new ReportCalculationEngine(_graph);
+            var results = engine.CalculateAll(
+                definitionLinks,
+                taskCY.Result,
+                taskPY.Result,
+                cyOpeningData:    taskPY.Result,
+                pyOpeningData:    taskPrior.Result,
+                cyJanOpeningData: taskJanCY.Result,
+                pyJanOpeningData: taskJanPY.Result,
+                pmData:           taskPM.Result);
+
+            PXTrace.WriteInformation($"[Slide] Calculation engine produced {results.Count} values in {stopwatch.ElapsedMilliseconds}ms");
+
+            // ── 7. Build markdown ──────────────────────────────────────────────────
+            var markdownBuilder = new MarkdownBuilderService();
+            string markdown = markdownBuilder.Build(_currentRecord, definitionsWithItems, results);
+            PXTrace.WriteInformation($"[Slide] Markdown built — {markdown.Length} chars");
+
+            return (markdown, definitionsWithItems);
+        }
+    }
+}

--- a/FinancialReport/Services/SlidesGptApiService.cs
+++ b/FinancialReport/Services/SlidesGptApiService.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PX.Data;
+
+namespace FinancialReport.Services
+{
+    /// <summary>
+    /// Calls the SlidesGPT API (api.slidesgpt.com) to generate a PowerPoint presentation from a text prompt.
+    /// Flow: POST /presentations/generate → synchronous response with id + download URL → GET download → binary PPTX.
+    /// Unlike Alai, generation is synchronous — no polling required.
+    /// </summary>
+    public class SlidesGptApiService
+    {
+        private const string BaseUrl = "https://api.slidesgpt.com/v1";
+
+        private readonly HttpClient _httpClient;
+
+        public SlidesGptApiService(string apiKey)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentNullException(nameof(apiKey));
+
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+            _httpClient.Timeout = TimeSpan.FromMinutes(5);
+        }
+
+        /// <summary>
+        /// Generates a presentation from the given prompt and returns the .pptx file bytes.
+        /// </summary>
+        /// <param name="prompt">The markdown / text prompt (5–64,000 characters).</param>
+        /// <param name="templateId">Optional SlidesGPT template ID. Pass null to use the default template.</param>
+        public byte[] GeneratePresentation(string prompt, string templateId = null)
+        {
+            string id = SubmitGeneration(prompt, templateId, out string downloadUrl);
+            PXTrace.WriteInformation($"[SlidesGPT] Presentation created. ID: {id}");
+
+            byte[] pptBytes = DownloadPresentation(downloadUrl);
+            PXTrace.WriteInformation($"[SlidesGPT] Downloaded {pptBytes.Length} bytes for ID: {id}");
+
+            return pptBytes;
+        }
+
+        private string SubmitGeneration(string prompt, string templateId, out string downloadUrl)
+        {
+            object payload = string.IsNullOrWhiteSpace(templateId)
+                ? (object)new { prompt = prompt }
+                : (object)new { prompt = prompt, templateId = templateId };
+
+            string json    = JsonConvert.SerializeObject(payload);
+            var content    = new StringContent(json, Encoding.UTF8, "application/json");
+            var response   = _httpClient.PostAsync($"{BaseUrl}/presentations/generate", content).Result;
+            string body    = response.Content.ReadAsStringAsync().Result;
+
+            if (!response.IsSuccessStatusCode)
+                throw new PXException($"[SlidesGPT] Generation failed ({(int)response.StatusCode}): {body}");
+
+            var result = JObject.Parse(body);
+            string id  = result["id"]?.ToString();
+            downloadUrl = result["download"]?.ToString();
+
+            if (string.IsNullOrEmpty(id))
+                throw new PXException($"[SlidesGPT] No presentation id returned. Response: {body}");
+
+            PXTrace.WriteInformation($"[SlidesGPT] Generation response — id={id}");
+            return id;
+        }
+
+        private byte[] DownloadPresentation(string downloadUrl)
+        {
+            // Use the signed download URL returned directly from the generate response (includes JWT token)
+            var response = _httpClient.GetAsync(downloadUrl).Result;
+
+            if (!response.IsSuccessStatusCode)
+                throw new PXException($"[SlidesGPT] Download failed ({(int)response.StatusCode}).");
+
+            return response.Content.ReadAsByteArrayAsync().Result;
+        }
+    }
+}

--- a/SQL/05_DeployAllTables-without-Presentation-columns.sql
+++ b/SQL/05_DeployAllTables-without-Presentation-columns.sql
@@ -35,12 +35,6 @@ BEGIN
         [UploadedFileIDDisplay]  [nvarchar](225)  NULL,
         [CompanyNum]             [int]            NULL,
         [Selected]               [bit]            NULL DEFAULT(0),
-        [PresentationTitle]      [nvarchar](500)  NULL,
-        [PresentationDescription][nvarchar](2000) NULL,
-        [GammaTemplateId]        [nvarchar](100)  NULL,
-        [SlideGeneratedFileID]   [uniqueidentifier] NULL,
-        [PresentationMarkdown]   [nvarchar](max)  NULL,
-        [SlideStatus]            [nvarchar](50)   NULL DEFAULT('File not Generated'),
         [NoteID]                 [uniqueidentifier] NOT NULL DEFAULT(NEWID()),
         [CreatedDateTime]        [datetime]       NOT NULL DEFAULT(GETDATE()),
         [CreatedByID]            [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
@@ -83,37 +77,6 @@ BEGIN
     BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [Organization] [nvarchar](50) NULL
           PRINT '  + Organization' END
 
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'PresentationTitle')
-    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [PresentationTitle] [nvarchar](500) NULL
-          PRINT '  + PresentationTitle' END
-
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'PresentationDescription')
-    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [PresentationDescription] [nvarchar](2000) NULL
-          PRINT '  + PresentationDescription' END
-
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'GammaTemplateId')
-    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [GammaTemplateId] [nvarchar](100) NULL
-          PRINT '  + GammaTemplateId' END
-
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'SlideGeneratedFileID')
-    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [SlideGeneratedFileID] [uniqueidentifier] NULL
-          PRINT '  + SlideGeneratedFileID' END
-
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'PresentationMarkdown')
-    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [PresentationMarkdown] [nvarchar](max) NULL
-          PRINT '  + PresentationMarkdown' END
-
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'SlideStatus')
-    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ADD [SlideStatus] [nvarchar](50) NULL DEFAULT('File not Generated')
-          PRINT '  + SlideStatus' END
-
-    -- Expand SlideStatus to NVARCHAR(50) if still at old size
-    IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-               WHERE TABLE_NAME = 'FLRTFinancialReport' AND COLUMN_NAME = 'SlideStatus'
-                 AND CHARACTER_MAXIMUM_LENGTH < 50)
-    BEGIN ALTER TABLE [dbo].[FLRTFinancialReport] ALTER COLUMN [SlideStatus] NVARCHAR(50) NULL
-          PRINT '  ~ SlideStatus expanded to NVARCHAR(50)' END
-
     PRINT 'FLRTFinancialReport column check done.'
 END
 GO
@@ -137,9 +100,6 @@ BEGIN
         [ClientSecretNew]        [nvarchar](255)  NULL,
         [UsernameNew]            [nvarchar](255)  NULL,
         [PasswordNew]            [nvarchar](255)  NULL,
-        [AlaiApiKey]             [nvarchar](255)  NULL,
-        [SlidesGptApiKey]        [nvarchar](255)  NULL,
-        [GammaApiKey]            [nvarchar](255)  NULL,
         [NoteID]                 [uniqueidentifier] NOT NULL DEFAULT(NEWID()),
         [CreatedDateTime]        [datetime]       NOT NULL DEFAULT(GETDATE()),
         [CreatedByID]            [uniqueidentifier] NOT NULL DEFAULT('00000000-0000-0000-0000-000000000000'),
@@ -177,18 +137,6 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'PasswordNew')
     BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [PasswordNew] [nvarchar](255) NULL
           PRINT '  + PasswordNew' END
-
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'AlaiApiKey')
-    BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [AlaiApiKey] [nvarchar](255) NULL
-          PRINT '  + AlaiApiKey' END
-
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'SlidesGptApiKey')
-    BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [SlidesGptApiKey] [nvarchar](255) NULL
-          PRINT '  + SlidesGptApiKey' END
-
-    IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'GammaApiKey')
-    BEGIN ALTER TABLE [dbo].[FLRTTenantCredentials] ADD [GammaApiKey] [nvarchar](255) NULL
-          PRINT '  + GammaApiKey' END
 
     -- Migrate: add CompanyID column and rebuild PK if CompanyID is missing
     IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'CompanyID')

--- a/SQL/07_AddPresentationFields.sql
+++ b/SQL/07_AddPresentationFields.sql
@@ -1,0 +1,71 @@
+-- =============================================
+-- FLRT Financial Report Module
+-- Migration 07: Add Presentation / Alai API fields
+-- Idempotent: safe to run multiple times.
+-- =============================================
+
+PRINT '======================================================'
+PRINT 'Migration 07 - Add Presentation Fields'
+PRINT '======================================================'
+
+-- =============================================
+-- FLRTFinancialReport: add presentation columns
+-- =============================================
+PRINT ''
+PRINT '--- FLRTFinancialReport: presentation fields ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'PresentationTitle')
+BEGIN
+    ALTER TABLE [dbo].[FLRTFinancialReport]
+        ADD [PresentationTitle] [nvarchar](500) NULL;
+    PRINT '  Added PresentationTitle'
+END
+ELSE
+    PRINT '  PresentationTitle already exists — skipped'
+
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'PresentationDescription')
+BEGIN
+    ALTER TABLE [dbo].[FLRTFinancialReport]
+        ADD [PresentationDescription] [nvarchar](2000) NULL;
+    PRINT '  Added PresentationDescription'
+END
+ELSE
+    PRINT '  PresentationDescription already exists — skipped'
+
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'SlideGeneratedFileID')
+BEGIN
+    ALTER TABLE [dbo].[FLRTFinancialReport]
+        ADD [SlideGeneratedFileID] [uniqueidentifier] NULL;
+    PRINT '  Added SlideGeneratedFileID'
+END
+ELSE
+    PRINT '  SlideGeneratedFileID already exists — skipped'
+
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'SlideStatus')
+BEGIN
+    ALTER TABLE [dbo].[FLRTFinancialReport]
+        ADD [SlideStatus] [nvarchar](20) NULL DEFAULT('File not Generated');
+    PRINT '  Added SlideStatus'
+END
+ELSE
+    PRINT '  SlideStatus already exists — skipped'
+
+-- =============================================
+-- FLRTTenantCredentials: add Alai API key column
+-- =============================================
+PRINT ''
+PRINT '--- FLRTTenantCredentials: Alai API key ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'AlaiApiKey')
+BEGIN
+    ALTER TABLE [dbo].[FLRTTenantCredentials]
+        ADD [AlaiApiKey] [nvarchar](255) NULL;
+    PRINT '  Added AlaiApiKey'
+END
+ELSE
+    PRINT '  AlaiApiKey already exists — skipped'
+
+PRINT ''
+PRINT '======================================================'
+PRINT 'Migration 07 complete.'
+PRINT '======================================================'

--- a/SQL/08_AddGammaApiKey.sql
+++ b/SQL/08_AddGammaApiKey.sql
@@ -1,0 +1,44 @@
+-- =============================================
+-- FLRT Financial Report Module
+-- Migration 08: Add Gamma API Key column
+-- Idempotent: safe to run multiple times.
+-- =============================================
+
+PRINT '======================================================'
+PRINT 'Migration 08 - Add Gamma API Key'
+PRINT '======================================================'
+
+-- =============================================
+-- FLRTTenantCredentials: add GammaApiKey column
+-- =============================================
+PRINT ''
+PRINT '--- FLRTTenantCredentials: GammaApiKey ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTTenantCredentials]') AND name = 'GammaApiKey')
+BEGIN
+    ALTER TABLE [dbo].[FLRTTenantCredentials]
+        ADD [GammaApiKey] [nvarchar](255) NULL;
+    PRINT '  Added GammaApiKey'
+END
+ELSE
+    PRINT '  GammaApiKey already exists — skipped'
+
+-- =============================================
+-- FLRTFinancialReport: add GammaTemplateId column
+-- =============================================
+PRINT ''
+PRINT '--- FLRTFinancialReport: GammaTemplateId ---'
+
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID(N'[dbo].[FLRTFinancialReport]') AND name = 'GammaTemplateId')
+BEGIN
+    ALTER TABLE [dbo].[FLRTFinancialReport]
+        ADD [GammaTemplateId] [nvarchar](100) NULL;
+    PRINT '  Added GammaTemplateId'
+END
+ELSE
+    PRINT '  GammaTemplateId already exists — skipped'
+
+PRINT ''
+PRINT '======================================================'
+PRINT 'Migration 08 complete.'
+PRINT '======================================================'


### PR DESCRIPTION
…tion

- Expand FLRTFinancialReport DAC with presentation fields (PresentationTitle, PresentationDescription, PresentationMarkdown, SlideStatus, SlideGeneratedFileID, GammaTemplateId)
- Increase Status field length from 20 to 50 characters to accommodate longer status values
- Add encrypted API key fields to FLRTTenantCredentials (AlaiApiKey, SlidesGptApiKey, GammaApiKey)
- Create new service classes for external API integration (AlaiApiService, GammaApiService, SlidesGptApiService, MarkdownBuilderService, SlideGenerationService)
- Add presentation generation actions to FLRTFinancialReportMaint (GeneratePresentation, DownloadPresentation, PreviewMarkdown, GenerateSlidesGpt, GenerateGamma)
- Implement slide status tracking and UI field enablement logic based on presentation generation state
- Add database migration scripts for presentation columns and Gamma API key configuration
- Update project file to include new service class references
- Add helper messages for presentation generation workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generate presentations automatically from financial report data using multiple external APIs
  * Preview markdown representations of financial data before generating presentations
  * Download generated presentation files for distribution
  * Configure API credentials securely for presentation generation services
  * Track slide generation status and monitor generation progress in real-time
  * Select and apply presentation templates for customized presentation outputs
  * Store generated presentation files and metadata within financial report records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->